### PR TITLE
✨ [feature] #29 - 커뮤니티 게시글 댓글, 북마크, 좋아요 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2' //Swagger 의존성 추가
 	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE' // AWS 서비스 의존성 추가
 	implementation 'org.springframework.boot:spring-boot-starter-validation' // validation
+	implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.0' // SQL 쿼리 파라미터 값 로그로 보여주는 라이브러리
+
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.microsoft.sqlserver:mssql-jdbc'

--- a/src/main/java/gaji/service/domain/common/annotation/CheckHashtagListElement.java
+++ b/src/main/java/gaji/service/domain/common/annotation/CheckHashtagListElement.java
@@ -1,0 +1,17 @@
+package gaji.service.domain.common.annotation;
+
+import gaji.service.domain.common.validation.HashtagListElementValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = HashtagListElementValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface CheckHashtagListElement {
+    String message() default "올바른 해시태그 값을 입력해주세요.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/gaji/service/domain/common/entity/BaseEntity.java
+++ b/src/main/java/gaji/service/domain/common/entity/BaseEntity.java
@@ -1,14 +1,21 @@
 package gaji.service.domain.common.entity;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+@Getter
 public abstract class BaseEntity {
     @CreatedDate
-    @Column(updatable = false)
+    @Column(updatable = false, nullable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate

--- a/src/main/java/gaji/service/domain/common/entity/Hashtag.java
+++ b/src/main/java/gaji/service/domain/common/entity/Hashtag.java
@@ -19,7 +19,7 @@ public class Hashtag extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(length = 30)
+    @Column(nullable = false, length = 30)
     private String name;
 
     @Builder

--- a/src/main/java/gaji/service/domain/common/entity/Hashtag.java
+++ b/src/main/java/gaji/service/domain/common/entity/Hashtag.java
@@ -14,7 +14,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Hashtag {
+public class Hashtag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/gaji/service/domain/common/entity/SelectHashtag.java
+++ b/src/main/java/gaji/service/domain/common/entity/SelectHashtag.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class SelectHashtag {
+public class SelectHashtag extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/gaji/service/domain/common/repository/SelectHashtagRepository.java
+++ b/src/main/java/gaji/service/domain/common/repository/SelectHashtagRepository.java
@@ -1,7 +1,10 @@
 package gaji.service.domain.common.repository;
 
 import gaji.service.domain.common.entity.SelectHashtag;
+import gaji.service.domain.enums.PostTypeEnum;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SelectHashtagRepository extends JpaRepository<SelectHashtag, Long> {
+
+    void deleteAllByEntityIdAndType(Long entityId, PostTypeEnum type);
 }

--- a/src/main/java/gaji/service/domain/common/validation/HashtagListElementValidator.java
+++ b/src/main/java/gaji/service/domain/common/validation/HashtagListElementValidator.java
@@ -1,0 +1,37 @@
+package gaji.service.domain.common.validation;
+
+import gaji.service.domain.common.annotation.CheckHashtagListElement;
+import gaji.service.domain.post.code.PostErrorStatus;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+public class HashtagListElementValidator implements ConstraintValidator<CheckHashtagListElement, List<String>> {
+
+    @Override
+    public void initialize(CheckHashtagListElement constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(List<String> values, ConstraintValidatorContext context) {
+        // null인 경우 유효성 검사에서 제외
+        if (values == null) {
+            return true;
+        }
+
+        // 리스트 안의 element중에서 하나라도 ["", " ", null]값에 해당되면 false, 아니면 true
+        boolean isValid = values.stream()
+                .allMatch(value -> value != null && !value.trim().isEmpty());
+
+        if (!isValid) {
+            context.disableDefaultConstraintViolation();
+            context.buildConstraintViolationWithTemplate(PostErrorStatus._HASHTAG_ISBLANK.getMessage()).addConstraintViolation();
+        }
+
+        return isValid;
+    }
+}

--- a/src/main/java/gaji/service/domain/enums/CommentStatus.java
+++ b/src/main/java/gaji/service/domain/enums/CommentStatus.java
@@ -1,5 +1,5 @@
 package gaji.service.domain.enums;
 
 public enum CommentStatus {
-    UPDATED, DELETE, PRIVATE // 수정, 삭제, 비밀댓글
+    PUBLIC, UPDATED, DELETE, PRIVATE // 기본, 수정, 삭제, 비밀댓글
 }

--- a/src/main/java/gaji/service/domain/post/code/PostErrorStatus.java
+++ b/src/main/java/gaji/service/domain/post/code/PostErrorStatus.java
@@ -11,8 +11,12 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum PostErrorStatus implements BaseErrorCodeInterface {
 
-    _POST_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4001", "존재하지 않는 게시글 유형입니다."),
+    _POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4001", "존재하지 않는 게시글입니다."),
+    _POST_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4002", "존재하지 않는 게시글 유형입니다."),
+    _COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4003", "존재하지 않는 댓글입니다."),
+
     _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_4001", "존재하지 않는 회원입니다."), // user 도메인을 건드리지 않기 위해 생성한 임시 에러코드
+
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/gaji/service/domain/post/code/PostErrorStatus.java
+++ b/src/main/java/gaji/service/domain/post/code/PostErrorStatus.java
@@ -13,8 +13,9 @@ public enum PostErrorStatus implements BaseErrorCodeInterface {
 
     _POST_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4001", "존재하지 않는 게시글입니다."),
     _POST_TYPE_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4002", "존재하지 않는 게시글 유형입니다."),
-    _COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4003", "존재하지 않는 댓글입니다."),
+    _HASHTAG_ISBLANK(HttpStatus.BAD_REQUEST, "POST_4003", "공백은 해시태그로 등록할 수 없습니다."),
 
+    _COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "POST_4004", "존재하지 않는 댓글입니다."),
     _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_4001", "존재하지 않는 회원입니다."), // user 도메인을 건드리지 않기 위해 생성한 임시 에러코드
 
     ;

--- a/src/main/java/gaji/service/domain/post/converter/PostConverter.java
+++ b/src/main/java/gaji/service/domain/post/converter/PostConverter.java
@@ -5,6 +5,8 @@ import gaji.service.domain.enums.PostStatusEnum;
 import gaji.service.domain.enums.PostTypeEnum;
 import gaji.service.domain.post.entity.Comment;
 import gaji.service.domain.post.entity.Post;
+import gaji.service.domain.post.entity.PostBookmark;
+import gaji.service.domain.post.entity.PostLikes;
 import gaji.service.domain.post.web.dto.PostRequestDTO;
 
 public class PostConverter {
@@ -34,5 +36,17 @@ public class PostConverter {
                 .build();
     }
 
+    public static PostBookmark toPostBookmark(User user, Post post) {
+        return PostBookmark.builder()
+                .user(user)
+                .post(post)
+                .build();
+    }
 
+    public static PostLikes toPostLikes(User user, Post post) {
+        return PostLikes.builder()
+                .user(user)
+                .post(post)
+                .build();
+    }
 }

--- a/src/main/java/gaji/service/domain/post/converter/PostConverter.java
+++ b/src/main/java/gaji/service/domain/post/converter/PostConverter.java
@@ -3,11 +3,13 @@ package gaji.service.domain.post.converter;
 import gaji.service.domain.User;
 import gaji.service.domain.enums.PostStatusEnum;
 import gaji.service.domain.enums.PostTypeEnum;
+import gaji.service.domain.post.entity.Comment;
 import gaji.service.domain.post.entity.Post;
 import gaji.service.domain.post.web.dto.PostRequestDTO;
 
 public class PostConverter {
 
+    // 초기 PostStatus 지정
     public static PostStatusEnum getInitialPostStatus(PostTypeEnum type) {
         return (type == PostTypeEnum.QUESTION) ? PostStatusEnum.NEED_RESOLUTION :
                 (type == PostTypeEnum.PROJECT_RECRUITMENT) ? PostStatusEnum.RECRUITING : PostStatusEnum.POSTING;
@@ -22,5 +24,15 @@ public class PostConverter {
                 .status(getInitialPostStatus(request.getType()))
                 .build();
     }
+
+    public static Comment toComment(PostRequestDTO.WriteCommentDTO request, User user, Post post, Comment parentComment) {
+        return Comment.builder()
+                .user(user)
+                .post(post)
+                .parent(parentComment)
+                .body(request.getBody())
+                .build();
+    }
+
 
 }

--- a/src/main/java/gaji/service/domain/post/entity/Comment.java
+++ b/src/main/java/gaji/service/domain/post/entity/Comment.java
@@ -1,9 +1,11 @@
 package gaji.service.domain.post.entity;
 
 import gaji.service.domain.User;
+import gaji.service.domain.common.entity.BaseEntity;
 import gaji.service.domain.enums.CommentStatus;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -13,7 +15,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Comment {
+public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -35,7 +37,23 @@ public class Comment {
     private List<Comment> replies = new ArrayList<>();
 
     private String body;
-    private int commentOrder;
+    private int orderNum;
     private int depth;
+    @Enumerated(EnumType.STRING)
     private CommentStatus status;
+
+    @Builder
+    public Comment(User user, Post post, Comment parent, String body) {
+        this.user = user;
+        this.post = post;
+        this.parent = parent;
+        this.body = body;
+        this.status = CommentStatus.PUBLIC; // 댓글은 기본상태
+        this.depth = (parent == null) ? 0 : parent.depth + 1; // 부모 댓글이 있으면 depth = (부모댓글의 depth + 1)
+        this.orderNum = (parent == null) ? post.getCommentOrderNum() : parent.getOrderNum(); // orderNum은 부모 댓글이 있으면 부모 댓글과 같은 값, 없으면 증가
+    }
+
+    public void updateStatus(CommentStatus status) {
+        this.status = status;
+    }
 }

--- a/src/main/java/gaji/service/domain/post/entity/Post.java
+++ b/src/main/java/gaji/service/domain/post/entity/Post.java
@@ -33,6 +33,9 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL)
     private List<PostLikes> postLikesList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> commentList = new ArrayList<>();
+
     private String title;
     private String body;
     private int views;

--- a/src/main/java/gaji/service/domain/post/entity/Post.java
+++ b/src/main/java/gaji/service/domain/post/entity/Post.java
@@ -1,6 +1,7 @@
 package gaji.service.domain.post.entity;
 
 import gaji.service.domain.User;
+import gaji.service.domain.common.entity.BaseEntity;
 import gaji.service.domain.enums.PostStatusEnum;
 import gaji.service.domain.enums.PostTypeEnum;
 import jakarta.persistence.*;
@@ -15,7 +16,7 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Post {
+public class Post extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -36,16 +37,22 @@ public class Post {
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Comment> commentList = new ArrayList<>();
 
+    @Column(nullable = false)
     private String title;
-    private String body;
-    private int views;
-    private int likes;
-    private int bookmarks;
+    @Column(nullable = false)
+    private String body; // TODO: 게시글 text 제한 20000자
+    private int viewCnt; // TODO: Integer vs int 고민해보기
+    private int likeCnt;
+    private int bookmarkCnt;
+    @Getter(AccessLevel.NONE)
+    private int commentOrderNum;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private PostTypeEnum type;
 
     @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
     private PostStatusEnum status;
 
     @Builder
@@ -60,8 +67,13 @@ public class Post {
     // 엔티티 생성 시 초기값 설정
     @PrePersist
     public void prePersist() {
-        this.views = 0;
-        this.likes = 0;
-        this.bookmarks = 0;
+        this.viewCnt = 0;
+        this.likeCnt = 0;
+        this.bookmarkCnt = 0;
+        this.commentOrderNum = 0;
+    }
+
+    public int getCommentOrderNum() {
+        return ++this.commentOrderNum;
     }
 }

--- a/src/main/java/gaji/service/domain/post/entity/Post.java
+++ b/src/main/java/gaji/service/domain/post/entity/Post.java
@@ -39,7 +39,7 @@ public class Post extends BaseEntity {
 
     @Column(nullable = false)
     private String title;
-    @Column(nullable = false)
+    @Column(nullable = false, columnDefinition = "TEXT")
     private String body; // TODO: 게시글 text 제한 20000자
     private int viewCnt; // TODO: Integer vs int 고민해보기
     private int likeCnt;
@@ -76,4 +76,21 @@ public class Post extends BaseEntity {
     public int getCommentOrderNum() {
         return ++this.commentOrderNum;
     }
+
+    public void increaseBookmarkCnt() {
+        this.bookmarkCnt++;
+    }
+
+    public void decreaseBookmarkCnt() {
+        this.bookmarkCnt--;
+    }
+
+    public void increaseLikeCnt() {
+        this.likeCnt++;
+    }
+
+    public void decreaseLikeCnt() {
+        this.likeCnt--;
+    }
+
 }

--- a/src/main/java/gaji/service/domain/post/entity/PostBookmark.java
+++ b/src/main/java/gaji/service/domain/post/entity/PostBookmark.java
@@ -3,6 +3,7 @@ package gaji.service.domain.post.entity;
 import gaji.service.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,4 +22,10 @@ public class PostBookmark {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private Post post;
+
+    @Builder
+    public PostBookmark(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
 }

--- a/src/main/java/gaji/service/domain/post/entity/PostLikes.java
+++ b/src/main/java/gaji/service/domain/post/entity/PostLikes.java
@@ -3,6 +3,7 @@ package gaji.service.domain.post.entity;
 import gaji.service.domain.User;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,5 +23,9 @@ public class PostLikes {
     @JoinColumn(name = "post_id")
     private Post post;
 
-
+    @Builder
+    public PostLikes(User user, Post post) {
+        this.user = user;
+        this.post = post;
+    }
 }

--- a/src/main/java/gaji/service/domain/post/repository/CommentRepository.java
+++ b/src/main/java/gaji/service/domain/post/repository/CommentRepository.java
@@ -1,0 +1,7 @@
+package gaji.service.domain.post.repository;
+
+import gaji.service.domain.post.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+}

--- a/src/main/java/gaji/service/domain/post/repository/PostBookmarkRepository.java
+++ b/src/main/java/gaji/service/domain/post/repository/PostBookmarkRepository.java
@@ -1,0 +1,11 @@
+package gaji.service.domain.post.repository;
+
+import gaji.service.domain.User;
+import gaji.service.domain.post.entity.Post;
+import gaji.service.domain.post.entity.PostBookmark;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostBookmarkRepository extends JpaRepository<PostBookmark, Long> {
+
+    void deleteByUserAndPost(User user, Post post);
+}

--- a/src/main/java/gaji/service/domain/post/repository/PostLikesRepository.java
+++ b/src/main/java/gaji/service/domain/post/repository/PostLikesRepository.java
@@ -1,0 +1,10 @@
+package gaji.service.domain.post.repository;
+
+import gaji.service.domain.User;
+import gaji.service.domain.post.entity.Post;
+import gaji.service.domain.post.entity.PostLikes;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PostLikesRepository extends JpaRepository<PostLikes, Long> {
+    void deleteByUserAndPost(User user, Post post);
+}

--- a/src/main/java/gaji/service/domain/post/service/PostCommandService.java
+++ b/src/main/java/gaji/service/domain/post/service/PostCommandService.java
@@ -1,10 +1,13 @@
 package gaji.service.domain.post.service;
 
+import gaji.service.domain.post.entity.Comment;
 import gaji.service.domain.post.entity.Post;
 import gaji.service.domain.post.web.dto.PostRequestDTO;
 
 public interface PostCommandService {
 
     Post uploadPost(Long userId, PostRequestDTO.UploadPostDTO request);
-
+    Comment writeCommentOnCommunityPost(Long userId, Long postId, Long parentCommentId, PostRequestDTO.WriteCommentDTO request);
+    void softDeleteComment(Long commentId);
+    void hardDeleteCommunityPost(Long postId);
 }

--- a/src/main/java/gaji/service/domain/post/service/PostCommandService.java
+++ b/src/main/java/gaji/service/domain/post/service/PostCommandService.java
@@ -2,6 +2,8 @@ package gaji.service.domain.post.service;
 
 import gaji.service.domain.post.entity.Comment;
 import gaji.service.domain.post.entity.Post;
+import gaji.service.domain.post.entity.PostBookmark;
+import gaji.service.domain.post.entity.PostLikes;
 import gaji.service.domain.post.web.dto.PostRequestDTO;
 
 public interface PostCommandService {
@@ -10,4 +12,9 @@ public interface PostCommandService {
     Comment writeCommentOnCommunityPost(Long userId, Long postId, Long parentCommentId, PostRequestDTO.WriteCommentDTO request);
     void softDeleteComment(Long commentId);
     void hardDeleteCommunityPost(Long postId);
+    PostBookmark bookmarkCommunityPost(Long userId, Long postId);
+    void cancelbookmarkCommunityPost(Long userId, Long postId);
+    PostLikes likeCommunityPost(Long userId, Long postId);
+    void cancelLikeCommunityPost(Long userId, Long postId);
+
 }

--- a/src/main/java/gaji/service/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/post/service/PostCommandServiceImpl.java
@@ -6,9 +6,12 @@ import gaji.service.domain.common.entity.Hashtag;
 import gaji.service.domain.common.entity.SelectHashtag;
 import gaji.service.domain.common.repository.HashtagRepository;
 import gaji.service.domain.common.repository.SelectHashtagRepository;
+import gaji.service.domain.enums.CommentStatus;
 import gaji.service.domain.post.code.PostErrorStatus;
 import gaji.service.domain.post.converter.PostConverter;
+import gaji.service.domain.post.entity.Comment;
 import gaji.service.domain.post.entity.Post;
+import gaji.service.domain.post.repository.CommentRepository;
 import gaji.service.domain.post.repository.PostRepository;
 import gaji.service.domain.post.web.dto.PostRequestDTO;
 import gaji.service.domain.user.repository.UserRepository;
@@ -29,25 +32,59 @@ public class PostCommandServiceImpl implements PostCommandService {
     private final PostRepository postRepository;
     private final HashtagRepository hashtagRepository;
     private final SelectHashtagRepository selectHashtagRepository;
+    private final CommentRepository commentRepository;
 
     @Override
     public Post uploadPost(Long userId, PostRequestDTO.UploadPostDTO request) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RestApiException(PostErrorStatus._USER_NOT_FOUND));
-        Post post = PostConverter.toPost(request, user);
+        User findUser = findUserByUserId(userId);
+        Post post = PostConverter.toPost(request, findUser);
         Post newPost = postRepository.save(post);
 
-        List<String> hashtagStringList = request.getHashtagList();
-        List<Hashtag> hashtagEntityList = getHashtagListByhashtagStringList(hashtagStringList);
+        if (request.getHashtagList() != null) {
+            List<String> hashtagStringList = request.getHashtagList();
+            List<Hashtag> hashtagEntityList = convertHashtagStringListToHashtagList(hashtagStringList);
 
-        List<SelectHashtag> selectHashtagList = HashtagConverter.toSelectHashtagList(hashtagEntityList, post.getId(), request.getType());
-        selectHashtagRepository.saveAll(selectHashtagList);
-
+            List<SelectHashtag> selectHashtagList = HashtagConverter.toSelectHashtagList(hashtagEntityList, post.getId(), request.getType());
+            selectHashtagRepository.saveAll(selectHashtagList);
+        }
         return newPost;
     }
 
+
+    @Override
+    public Comment writeCommentOnCommunityPost(Long userId, Long postId, Long parentCommentId, PostRequestDTO.WriteCommentDTO request) {
+        User findUser = findUserByUserId(userId);
+        Post findPost = findPostByPostId(postId);
+
+        Comment newComment = createCommentByCheckParentCommentIdIsNull(parentCommentId, request, findUser, findPost);
+        return commentRepository.save(newComment);
+    }
+
+    @Override
+    public void softDeleteComment(Long commentId) {
+        Comment findComment = findCommentByCommentId(commentId);
+        findComment.updateStatus(CommentStatus.DELETE);
+    }
+
+    // TODO: 게시글 파일도 함께 삭제
+    @Override
+    public void hardDeleteCommunityPost(Long postId) {
+        Post findPost = findPostByPostId(postId);
+        selectHashtagRepository.deleteAllByEntityIdAndType(findPost.getId(), findPost.getType());
+        postRepository.delete(findPost);
+    }
+
+    private Comment createCommentByCheckParentCommentIdIsNull(Long parentCommentId, PostRequestDTO.WriteCommentDTO request, User findUser, Post findPost) {
+        if (parentCommentId != null) {
+            Comment parentComment = findCommentByCommentId(parentCommentId);
+            return PostConverter.toComment(request, findUser, findPost, parentComment);
+        } else {
+            return PostConverter.toComment(request, findUser, findPost, null);
+        }
+    }
+
     // 이미 존재하는 해시태그는 조회, 존재하지 않는 해시태그는 생성해서 List로 반환하는 메서드
-    private List<Hashtag> getHashtagListByhashtagStringList(List<String> hashtagStringList) {
+    private List<Hashtag> convertHashtagStringListToHashtagList(List<String> hashtagStringList) {
         return hashtagStringList.stream()
                 .map(hashtag -> {
                     if (hashtagRepository.existsByName(hashtag)) {
@@ -57,5 +94,20 @@ public class PostCommandServiceImpl implements PostCommandService {
                     }
                 })
                 .collect(Collectors.toList());
+    }
+
+    private User findUserByUserId(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(PostErrorStatus._USER_NOT_FOUND));
+    }
+
+    private Post findPostByPostId(Long postId) {
+        return postRepository.findById(postId)
+                .orElseThrow(() -> new RestApiException(PostErrorStatus._POST_NOT_FOUND));
+    }
+
+    private Comment findCommentByCommentId(Long parentCommentId) {
+        return commentRepository.findById(parentCommentId)
+                .orElseThrow(() -> new RestApiException(PostErrorStatus._COMMENT_NOT_FOUND));
     }
 }

--- a/src/main/java/gaji/service/domain/post/service/PostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/post/service/PostCommandServiceImpl.java
@@ -15,12 +15,14 @@ import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class PostCommandServiceImpl implements PostCommandService {
 
     private final UserRepository userRepository;

--- a/src/main/java/gaji/service/domain/post/web/controller/PostRestController.java
+++ b/src/main/java/gaji/service/domain/post/web/controller/PostRestController.java
@@ -1,18 +1,19 @@
 package gaji.service.domain.post.web.controller;
 
+import gaji.service.domain.post.entity.Comment;
 import gaji.service.domain.post.entity.Post;
 import gaji.service.domain.post.service.PostCommandService;
 import gaji.service.domain.post.web.dto.PostRequestDTO;
 import gaji.service.global.base.BaseResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 
+//@Validated
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/community-posts")
@@ -21,11 +22,47 @@ public class PostRestController {
     private final PostCommandService postCommandService;
 
     @PostMapping
-    @Operation(summary = "커뮤니티 게시글 업로드 API",description = "커뮤니티의 게시글을 업로드하는 API입니다. 게시글 유형과 제목, 본문 내용을 검증합니다.")
-    public BaseResponse<Long> uploadPost(Long userId, @RequestBody @Valid PostRequestDTO.UploadPostDTO request) {
+    @Operation(summary = "커뮤니티 게시글 업로드 API", description = "커뮤니티의 게시글을 업로드하는 API입니다. 게시글 유형과 제목, 본문 내용을 검증합니다.")
+    public BaseResponse<Long> uploadPost(Long userId,
+                                         @RequestBody @Valid PostRequestDTO.UploadPostDTO request) {
         Post newPost = postCommandService.uploadPost(userId, request);
         return BaseResponse.onSuccess(newPost.getId());
     }
+
+    @PostMapping("/{postId}/comments")
+    @Operation(summary = "커뮤니티 게시글 댓글 작성 API", description = "커뮤니티의 게시글에 댓글을 작성하는 API입니다. 대댓글을 작성하는 거라면 Long 타입의 parentCommentId를 query parameter로 보내주시면 됩니다!")
+    @Parameters({
+            @Parameter(name = "userId", description = "회원 id"),
+            @Parameter(name = "postId", description = "게시글 id"),
+            @Parameter(name = "parentCommentId", description = "부모 댓글의 id, 대댓글 작성할 때 필요한 부모 댓글의 id입니다."),
+    })
+    public BaseResponse<Long> writeCommentOnCommunityPost(@RequestParam Long userId,
+                                                          @PathVariable Long postId,
+                                                          @RequestParam(required = false) Long parentCommentId,
+                                                          @RequestBody @Valid PostRequestDTO.WriteCommentDTO request) {
+        Comment newComment = postCommandService.writeCommentOnCommunityPost(userId, postId, parentCommentId, request);
+        return BaseResponse.onSuccess(newComment.getId());
+    }
+
+    @DeleteMapping("/comments/{commentId}")
+    @Operation(summary = "커뮤니티 게시글 댓글 삭제 API", description = "커뮤니티 게시글의 댓글을 삭제하는 API입니다. Comment를 DB에서 바로 삭제하지 않고 status를 DELETE로만 바꿉니다.(soft delete)")
+    @Parameters({
+            @Parameter(name = "commentId", description = "댓글 id"),
+    })
+    public BaseResponse softDeleteComment(@PathVariable Long commentId) {
+        postCommandService.softDeleteComment(commentId);
+        return BaseResponse.onSuccess(null);
+    }
+
+    @DeleteMapping("/{postId}")
+    @Operation(summary = "커뮤니티 게시글 삭제 API", description = "커뮤니티 게시글을 삭제하는 API입니다. 게시글과 관련된 북마크, 좋아요, 댓글 내역을 모두 삭제합니다.(hard delete)")
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글 id"),
+    })    public BaseResponse hardDeleteCommunityPost(@PathVariable Long postId) {
+        postCommandService.hardDeleteCommunityPost(postId);
+        return BaseResponse.onSuccess(null);
+    }
+
 
 
 }

--- a/src/main/java/gaji/service/domain/post/web/controller/PostRestController.java
+++ b/src/main/java/gaji/service/domain/post/web/controller/PostRestController.java
@@ -2,6 +2,8 @@ package gaji.service.domain.post.web.controller;
 
 import gaji.service.domain.post.entity.Comment;
 import gaji.service.domain.post.entity.Post;
+import gaji.service.domain.post.entity.PostBookmark;
+import gaji.service.domain.post.entity.PostLikes;
 import gaji.service.domain.post.service.PostCommandService;
 import gaji.service.domain.post.web.dto.PostRequestDTO;
 import gaji.service.global.base.BaseResponse;
@@ -49,7 +51,7 @@ public class PostRestController {
     @Parameters({
             @Parameter(name = "commentId", description = "댓글 id"),
     })
-    public BaseResponse softDeleteComment(@PathVariable Long commentId) {
+    public BaseResponse softDeleteComment(Long userId, @PathVariable Long commentId) {
         postCommandService.softDeleteComment(commentId);
         return BaseResponse.onSuccess(null);
     }
@@ -58,8 +60,49 @@ public class PostRestController {
     @Operation(summary = "커뮤니티 게시글 삭제 API", description = "커뮤니티 게시글을 삭제하는 API입니다. 게시글과 관련된 북마크, 좋아요, 댓글 내역을 모두 삭제합니다.(hard delete)")
     @Parameters({
             @Parameter(name = "postId", description = "게시글 id"),
-    })    public BaseResponse hardDeleteCommunityPost(@PathVariable Long postId) {
+    })
+    public BaseResponse hardDeleteCommunityPost(Long userId, @PathVariable Long postId) {
         postCommandService.hardDeleteCommunityPost(postId);
+        return BaseResponse.onSuccess(null);
+    }
+
+    @PostMapping("/{postId}/bookmarks")
+    @Operation(summary = "커뮤니티 게시글 북마크 API", description = "커뮤니티 게시글을 북마크하는 API입니다.")
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글 id"),
+    })
+    public BaseResponse<Long> bookmarkCommunityPost(Long userId, @PathVariable Long postId) {
+        PostBookmark newPostBookmark = postCommandService.bookmarkCommunityPost(userId, postId);
+        return BaseResponse.onSuccess(newPostBookmark.getId());
+    }
+
+    @DeleteMapping("/{postId}/bookmarks")
+    @Operation(summary = "커뮤니티 게시글 북마크 취소 API", description = "커뮤니티 게시글을 북마크 취소하는 API입니다.")
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글 id"),
+    })
+    public BaseResponse cancelBookmarkCommunityPost(Long userId, @PathVariable Long postId) {
+        postCommandService.cancelbookmarkCommunityPost(userId, postId);
+        return BaseResponse.onSuccess(null);
+    }
+
+    @PostMapping("/{postId}/likes")
+    @Operation(summary = "커뮤니티 게시글 좋아요 API", description = "커뮤니티 게시글을 좋아요하는 API입니다.")
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글 id"),
+    })
+    public BaseResponse<Long> likeCommunityPost(Long userId, @PathVariable Long postId) {
+        PostLikes newPostLikes = postCommandService.likeCommunityPost(userId, postId);
+        return BaseResponse.onSuccess(newPostLikes.getId());
+    }
+
+    @DeleteMapping("/{postId}/likes")
+    @Operation(summary = "커뮤니티 게시글 좋아요 취소 API", description = "커뮤니티 게시글을 좋아요 취소하는 API입니다.")
+    @Parameters({
+            @Parameter(name = "postId", description = "게시글 id"),
+    })
+    public BaseResponse cancelLikeCommunityPost(Long userId, @PathVariable Long postId) {
+        postCommandService.cancelLikeCommunityPost(userId, postId);
         return BaseResponse.onSuccess(null);
     }
 

--- a/src/main/java/gaji/service/domain/post/web/dto/PostRequestDTO.java
+++ b/src/main/java/gaji/service/domain/post/web/dto/PostRequestDTO.java
@@ -1,5 +1,6 @@
 package gaji.service.domain.post.web.dto;
 
+import gaji.service.domain.common.annotation.CheckHashtagListElement;
 import gaji.service.domain.enums.PostTypeEnum;
 import gaji.service.domain.post.annotation.ExistPostType;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -30,6 +31,7 @@ public class PostRequestDTO {
 
         // TODO: List의 요소 중 ""," ", null이 포함되지 않도록 검증
         @Schema(description = "해시태그 리스트")
+        @CheckHashtagListElement
         private final List<String> hashtagList = new ArrayList<>();
     }
 

--- a/src/main/java/gaji/service/domain/post/web/dto/PostRequestDTO.java
+++ b/src/main/java/gaji/service/domain/post/web/dto/PostRequestDTO.java
@@ -28,7 +28,18 @@ public class PostRequestDTO {
         @ExistPostType
         private final PostTypeEnum type;
 
+        // TODO: List의 요소 중 ""," ", null이 포함되지 않도록 검증
         @Schema(description = "해시태그 리스트")
         private final List<String> hashtagList = new ArrayList<>();
     }
+
+    @Schema(description = "커뮤니티 게시글 댓글 작성 DTO")
+    @Getter
+    @RequiredArgsConstructor
+    public static class WriteCommentDTO {
+        @Schema(description = "댓글 본문")
+        @NotBlank(message = "댓글 본문을 입력해주세요.")
+        private String body;
+    }
+
 }

--- a/src/main/java/gaji/service/domain/user/annotation/ExistUser.java
+++ b/src/main/java/gaji/service/domain/user/annotation/ExistUser.java
@@ -1,0 +1,17 @@
+package gaji.service.domain.user.annotation;
+
+import gaji.service.domain.user.validation.UserExistValidator;
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+
+import java.lang.annotation.*;
+
+@Documented
+@Constraint(validatedBy = UserExistValidator.class)
+@Target( { ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ExistUser {
+    String message() default "존재하지 않는 회원입니다.";
+    Class<?>[] groups() default {};
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/gaji/service/domain/user/service/UserQueryService.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryService.java
@@ -1,0 +1,6 @@
+package gaji.service.domain.user.service;
+
+public interface UserQueryService {
+
+    boolean existUserById(Long userId);
+}

--- a/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
@@ -1,0 +1,19 @@
+package gaji.service.domain.user.service;
+
+import gaji.service.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserQueryServiceImpl implements UserQueryService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public boolean existUserById(Long userId) {
+        return userRepository.existsById(userId);
+    }
+}

--- a/src/main/java/gaji/service/domain/user/validation/UserExistValidator.java
+++ b/src/main/java/gaji/service/domain/user/validation/UserExistValidator.java
@@ -1,0 +1,34 @@
+package gaji.service.domain.user.validation;
+
+import gaji.service.domain.user.annotation.ExistUser;
+import gaji.service.domain.post.code.PostErrorStatus;
+import gaji.service.domain.user.service.UserQueryService;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserExistValidator implements ConstraintValidator<ExistUser, Long> {
+
+    private final UserQueryService userQueryService;
+
+    @Override
+    public void initialize(ExistUser constraintAnnotation) {
+        ConstraintValidator.super.initialize(constraintAnnotation);
+    }
+
+    @Override
+    public boolean isValid(Long value, ConstraintValidatorContext context) {
+        boolean isExist = userQueryService.existUserById(value); // user가 존재하면 1 아니면 0
+
+        if (!isExist) {
+            context.disableDefaultConstraintViolation();
+            // TODO: UserErrorStatus에 _USER_NOT_FOUND 추가해서 사용해주기
+            context.buildConstraintViolationWithTemplate(PostErrorStatus._USER_NOT_FOUND.getMessage()).addConstraintViolation();
+        }
+
+        return isExist;
+    }
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#29-write-comment-on-community-posts -> develop

## 변경 사항
- 커뮤니티 게시글 업로드 API 수정: 요청의 hashtagList의 요소들 중 공백이 존재하는지 검증하는 애노테이션 추가(`@CheckHashtagListElement`)
- 커뮤니티 게시글 삭제 API 구현: Post와 연관된 SelectHashtag 엔티티를 삭제하고, Post를 hard delete
- 커뮤니티 게시글 댓글 작성 API 구현: 요청 경로에 parentCommentId라는 쿼리 파라미터 값이 존재하면 대댓글 생성, 존재하지 않으면 root 댓글(depth=0) 생성 
- 커뮤니티 게시글 댓글 삭제 API 구현: DB에서 삭제하지 않고 status값만 DELETED로 바꾸는 soft delete 방식으로 구현
- 커뮤니티 게시글 북마크, 북마크 취소 API 구현
- 커뮤니티 게시글 좋아요, 좋아요 취소 API 구현


## 이슈
- 리소스를 삭제하는 API의 경우 해당 리소스의 소유자가 맞는지 검증하는 로직을 추가해야함. 커스텀 annotation이 쿼리파라미터나 path variable에 적용되지 않아 다른 방법을 찾아야함
- 좋아요, 북마크 API의 경우 이미 좋아요나 북마크한 게시글인지 검증해야함
- 게시글의 body가 20000자까지 허용돼야해서 일단 MariaDB라고 가정하고 `@Column(columnDefinition = "TEXT")`을 적용함

## 테스트 결과

### 커뮤니티 게시글 삭제 API

![image](https://github.com/user-attachments/assets/5e4ba388-d722-414f-8009-6016884d96ad)


### 커뮤니티 게시글 댓글 작성 API

![image](https://github.com/user-attachments/assets/6dfbf243-9b2d-4289-a513-ef002bf7bfe5)
![스크린샷 2024-07-29 160446](https://github.com/user-attachments/assets/980025ca-8027-483c-be5d-1a166d58d88d)

### 커뮤니티 게시글 댓글 삭제 API
![image](https://github.com/user-attachments/assets/d2b6a390-1017-4e5b-9ecb-9ae70495b448)


### 커뮤니티 게시글 좋아요 API

![image](https://github.com/user-attachments/assets/3dcae51a-68fc-46d9-8567-cd6f59f5412c)

### 커뮤니티 게시글 좋아요 취소 API

![image](https://github.com/user-attachments/assets/0550f05e-5a66-419c-80b4-3b46fccd3871)


### 커뮤니티 게시글 북마크 API
![image](https://github.com/user-attachments/assets/4d163942-9142-430b-97bc-ff9f1f3d4457)


### 커뮤니티 게시글 북마크 취소 API
![image](https://github.com/user-attachments/assets/42cb47b9-d538-4df0-802e-f3b9d39b11cc)





