### PR TITLE
✨ [feature] #50 -스터디름 게시판 등록 API 구현

### DIFF
--- a/src/main/java/gaji/service/domain/User.java
+++ b/src/main/java/gaji/service/domain/User.java
@@ -11,7 +11,7 @@ import gaji.service.domain.post.entity.*;
 import gaji.service.domain.recruite.*;
 import gaji.service.domain.room.entity.Event;
 import gaji.service.domain.room.entity.VoiceChatUser;
-import gaji.service.domain.roomPost.*;
+import gaji.service.domain.roomPost.entity.*;
 import gaji.service.domain.studyMate.*;
 import jakarta.persistence.*;
 import lombok.AccessLevel;

--- a/src/main/java/gaji/service/domain/post/entity/Post.java
+++ b/src/main/java/gaji/service/domain/post/entity/Post.java
@@ -52,6 +52,7 @@ public class Post extends BaseEntity {
     private PostTypeEnum type;
 
     @Enumerated(EnumType.STRING)
+
     @Column(nullable = false)
     private PostStatusEnum status;
 

--- a/src/main/java/gaji/service/domain/room/converter/RoomConverter.java
+++ b/src/main/java/gaji/service/domain/room/converter/RoomConverter.java
@@ -12,4 +12,5 @@ public class RoomConverter {
                 .body(assignment.getBody())
                 .build();
     }
+
 }

--- a/src/main/java/gaji/service/domain/room/entity/Room.java
+++ b/src/main/java/gaji/service/domain/room/entity/Room.java
@@ -67,4 +67,5 @@ public class Room {
     private LocalDate startDay;
     private LocalDate endDay;
 
+
 }

--- a/src/main/java/gaji/service/domain/room/entity/Room.java
+++ b/src/main/java/gaji/service/domain/room/entity/Room.java
@@ -2,7 +2,7 @@ package gaji.service.domain.room.entity;
 
 import gaji.service.domain.curriculum.Curriculum;
 import gaji.service.domain.recruite.RecruitPost;
-import gaji.service.domain.roomPost.RoomBoard;
+import gaji.service.domain.roomPost.entity.RoomBoard;
 import gaji.service.domain.studyMate.Assignment;
 import gaji.service.domain.studyMate.Chat;
 import gaji.service.domain.studyMate.StudyApplicant;

--- a/src/main/java/gaji/service/domain/room/service/RoomCommandService.java
+++ b/src/main/java/gaji/service/domain/room/service/RoomCommandService.java
@@ -8,4 +8,6 @@ import jakarta.transaction.Transactional;
 public interface RoomCommandService {
     @Transactional
     Assignment createAssignment(Long roomId, Long userId, RoomRequestDto.AssignmentDto requestDto);
+
+
 }

--- a/src/main/java/gaji/service/domain/room/service/RoomCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/room/service/RoomCommandServiceImpl.java
@@ -6,7 +6,6 @@ import gaji.service.domain.room.entity.Room;
 import gaji.service.domain.room.repository.AssignmentRepository;
 import gaji.service.domain.room.repository.RoomRepository;
 import gaji.service.domain.room.web.dto.RoomRequestDto;
-import gaji.service.domain.room.web.dto.RoomResponseDto;
 import gaji.service.domain.studyMate.Assignment;
 import gaji.service.domain.studyMate.repository.StudyMateRepository;
 import gaji.service.domain.user.repository.UserRepository;
@@ -55,5 +54,6 @@ public class RoomCommandServiceImpl implements RoomCommandService {
         Assignment savedAssignment = assignmentRepository.save(assignment);
         return savedAssignment;
     }
+
 
 }

--- a/src/main/java/gaji/service/domain/room/service/RoomQueryService.java
+++ b/src/main/java/gaji/service/domain/room/service/RoomQueryService.java
@@ -1,0 +1,8 @@
+package gaji.service.domain.room.service;
+
+import gaji.service.domain.room.entity.Room;
+
+public interface RoomQueryService {
+
+    Room findRoomById(Long roomId);
+}

--- a/src/main/java/gaji/service/domain/room/service/RoomQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/room/service/RoomQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package gaji.service.domain.room.service;
+
+import gaji.service.domain.room.code.RoomErrorStatus;
+import gaji.service.domain.room.entity.Room;
+import gaji.service.domain.room.repository.RoomRepository;
+import gaji.service.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class RoomQueryServiceImpl implements RoomQueryService {
+
+    private final RoomRepository roomRepository;
+
+    @Override
+    public Room findRoomById(Long roomId){
+        return roomRepository.findById(roomId)
+                .orElseThrow(() -> new RestApiException(RoomErrorStatus._ROOM_NOT_FOUND));
+    }
+}

--- a/src/main/java/gaji/service/domain/room/web/controller/RoomController.java
+++ b/src/main/java/gaji/service/domain/room/web/controller/RoomController.java
@@ -16,13 +16,21 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/studyRooms")
 public class RoomController {
 
-    private final RoomCommandServiceImpl assignmentService;
+    private final RoomCommandServiceImpl roomCommandService;
 
     @PostMapping("/assignments/{roomId}/{userId}")
     @Operation(summary = "스터디룸 과제 등록 API",description = "스터디룸의 과제를 등록하는 API입니다. room의 id가 존재하는지, 스터디에 참혀하고 있는 user인지 검증합니다.")
     public BaseResponse<RoomResponseDto.AssignmentDto> AssignmentController(@PathVariable Long userId/*하드 코딩용, 추후 삭제*/, @RequestBody @Valid RoomRequestDto.AssignmentDto requestDto, @PathVariable Long roomId){
         //Long userId = getUserIdFromToken(token);
-        Assignment assignment = assignmentService.createAssignment(roomId, userId, requestDto);
+        Assignment assignment = roomCommandService.createAssignment(roomId, userId, requestDto);
+        return BaseResponse.onSuccess(RoomConverter.toAssignmentDto(assignment));
+    }
+
+    @PostMapping("/boards/{roomId}/{userId}"/*userId는 테스트를 위한 것, 추후에 삭제 예정*/)
+    @Operation(summary = "스터디룸 게시글 등록 API",description = "스터디룸의 게시글을 등록하는 API입니다. room의 id가 존재하는지, 스터디에 참혀하고 있는 user인지 검증합니다.")
+    public BaseResponse<RoomResponseDto.BoardDto> RoomBoardController(@PathVariable Long userId/*하드 코딩용, 추후 삭제*/, @RequestBody @Valid RoomRequestDto.AssignmentDto requestDto, @PathVariable Long roomId){
+        //Long userId = getUserIdFromToken(token);
+        Assignment assignment = roomCommandService.createBoard();
         return BaseResponse.onSuccess(RoomConverter.toAssignmentDto(assignment));
     }
 

--- a/src/main/java/gaji/service/domain/room/web/controller/RoomController.java
+++ b/src/main/java/gaji/service/domain/room/web/controller/RoomController.java
@@ -26,12 +26,4 @@ public class RoomController {
         return BaseResponse.onSuccess(RoomConverter.toAssignmentDto(assignment));
     }
 
-    @PostMapping("/boards/{roomId}/{userId}"/*userId는 테스트를 위한 것, 추후에 삭제 예정*/)
-    @Operation(summary = "스터디룸 게시글 등록 API",description = "스터디룸의 게시글을 등록하는 API입니다. room의 id가 존재하는지, 스터디에 참혀하고 있는 user인지 검증합니다.")
-    public BaseResponse<RoomResponseDto.BoardDto> RoomBoardController(@PathVariable Long userId/*하드 코딩용, 추후 삭제*/, @RequestBody @Valid RoomRequestDto.AssignmentDto requestDto, @PathVariable Long roomId){
-        //Long userId = getUserIdFromToken(token);
-        Assignment assignment = roomCommandService.createBoard();
-        return BaseResponse.onSuccess(RoomConverter.toAssignmentDto(assignment));
-    }
-
 }

--- a/src/main/java/gaji/service/domain/room/web/dto/RoomRequestDto.java
+++ b/src/main/java/gaji/service/domain/room/web/dto/RoomRequestDto.java
@@ -1,7 +1,11 @@
 package gaji.service.domain.room.web.dto;
 
+import gaji.service.domain.common.annotation.CheckHashtagListElement;
+import gaji.service.domain.enums.PostTypeEnum;
+import gaji.service.domain.post.annotation.ExistPostType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
@@ -28,6 +32,28 @@ public class RoomRequestDto {
         private List<String> bodyList = new ArrayList<>();
 
     }
+
+    @Schema(description = "스터디 게시글 DTO")
+    @Getter
+    @RequiredArgsConstructor
+    public static class BoardDto {
+        @Schema(description = "게시글 제목")
+        @NotBlank(message = "제목을 입력해주세요.")
+        private final String title;
+
+        @Schema(description = "게시글 본문")
+        @NotBlank(message = "게시글 본문을 입력해주세요.")
+        private final String body;
+
+        @Schema(description = "Enum 종류(프로젝트 모집, 질문, 블로그)")
+        @ExistPostType
+        private final PostTypeEnum type;
+
+        @Schema(description = "태그 리스트")
+        @CheckHashtagListElement
+        private final List<String> hashtagList = new ArrayList<>();
+    }
+
 
 
 }

--- a/src/main/java/gaji/service/domain/room/web/dto/RoomRequestDto.java
+++ b/src/main/java/gaji/service/domain/room/web/dto/RoomRequestDto.java
@@ -33,27 +33,4 @@ public class RoomRequestDto {
 
     }
 
-    @Schema(description = "스터디 게시글 DTO")
-    @Getter
-    @RequiredArgsConstructor
-    public static class BoardDto {
-        @Schema(description = "게시글 제목")
-        @NotBlank(message = "제목을 입력해주세요.")
-        private final String title;
-
-        @Schema(description = "게시글 본문")
-        @NotBlank(message = "게시글 본문을 입력해주세요.")
-        private final String body;
-
-        @Schema(description = "Enum 종류(프로젝트 모집, 질문, 블로그)")
-        @ExistPostType
-        private final PostTypeEnum type;
-
-        @Schema(description = "태그 리스트")
-        @CheckHashtagListElement
-        private final List<String> hashtagList = new ArrayList<>();
-    }
-
-
-
 }

--- a/src/main/java/gaji/service/domain/room/web/dto/RoomResponseDto.java
+++ b/src/main/java/gaji/service/domain/room/web/dto/RoomResponseDto.java
@@ -16,15 +16,5 @@ public class RoomResponseDto {
         String body;
     }
 
-    @Builder
-    @Getter
-    @NoArgsConstructor
-    @AllArgsConstructor
-    public static class BoardDto{
-        String title;
-        String body;
-        PostTypeEnum postTypeEnum;
-    }
-
 
 }

--- a/src/main/java/gaji/service/domain/room/web/dto/RoomResponseDto.java
+++ b/src/main/java/gaji/service/domain/room/web/dto/RoomResponseDto.java
@@ -1,5 +1,6 @@
 package gaji.service.domain.room.web.dto;
 
+import gaji.service.domain.enums.PostTypeEnum;
 import gaji.service.domain.studyMate.Assignment;
 import lombok.*;
 
@@ -14,5 +15,16 @@ public class RoomResponseDto {
         Integer weeks;
         String body;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class BoardDto{
+        String title;
+        String body;
+        PostTypeEnum postTypeEnum;
+    }
+
 
 }

--- a/src/main/java/gaji/service/domain/roomPost/code/RoomPostErrorStatus.java
+++ b/src/main/java/gaji/service/domain/roomPost/code/RoomPostErrorStatus.java
@@ -1,0 +1,32 @@
+package gaji.service.domain.roomPost.code;
+
+import gaji.service.global.exception.code.BaseCodeDto;
+import gaji.service.global.exception.code.BaseErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum RoomPostErrorStatus implements BaseErrorCodeInterface {
+    // 스터디룸 게시판
+    _ROOM_BOARD_NOT_FOUND(HttpStatus.BAD_REQUEST, "ROOM_4001", "존재하지 않는 게시판입니다.");
+
+
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess = false;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCodeDto getErrorCode() {
+        return BaseCodeDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
+++ b/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
@@ -4,6 +4,8 @@ import gaji.service.domain.User;
 import gaji.service.domain.roomPost.entity.RoomPost;
 import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
 
+import java.time.LocalDateTime;
+
 import static gaji.service.domain.post.converter.PostConverter.getInitialPostStatus;
 
 public class RoomPostConverter {
@@ -13,9 +15,9 @@ public class RoomPostConverter {
                  .user(user)
                  .title(requestDto.getTitle())
                  .body(requestDto.getBody())
-                 .type(requestDto.getType())
-                 .status(getInitialPostStatus(requestDto.getType()))
+                 .postTime(LocalDateTime.now())
                  .build();
+         return roomPost;
     }
 
 

--- a/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
+++ b/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
@@ -1,21 +1,21 @@
 package gaji.service.domain.roomPost.converter;
 
 import gaji.service.domain.User;
+import gaji.service.domain.roomPost.entity.RoomBoard;
 import gaji.service.domain.roomPost.entity.RoomPost;
 import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
 
 import java.time.LocalDateTime;
 
-import static gaji.service.domain.post.converter.PostConverter.getInitialPostStatus;
-
 public class RoomPostConverter {
 
-    public static RoomPost toPost(RoomPostRequestDto.RoomPostDto requestDto, User user) {
+    public static RoomPost toPost(RoomPostRequestDto.RoomPostDto requestDto, User user, RoomBoard roomBoard) {
          RoomPost roomPost = RoomPost.builder()
                  .user(user)
                  .title(requestDto.getTitle())
                  .body(requestDto.getBody())
                  .postTime(LocalDateTime.now())
+                 .roomBoard(roomBoard)
                  .build();
          return roomPost;
     }

--- a/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
+++ b/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
@@ -9,7 +9,7 @@ import java.time.LocalDateTime;
 
 public class RoomPostConverter {
 
-    public static RoomPost toPost(RoomPostRequestDto.RoomPostDto requestDto, User user, RoomBoard roomBoard) {
+    public static RoomPost toRoomPost(RoomPostRequestDto.RoomPostDto requestDto, User user, RoomBoard roomBoard) {
          RoomPost roomPost = RoomPost.builder()
                  .user(user)
                  .title(requestDto.getTitle())

--- a/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
+++ b/src/main/java/gaji/service/domain/roomPost/converter/RoomPostConverter.java
@@ -1,0 +1,22 @@
+package gaji.service.domain.roomPost.converter;
+
+import gaji.service.domain.User;
+import gaji.service.domain.roomPost.entity.RoomPost;
+import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
+
+import static gaji.service.domain.post.converter.PostConverter.getInitialPostStatus;
+
+public class RoomPostConverter {
+
+    public static RoomPost toPost(RoomPostRequestDto.RoomPostDto requestDto, User user) {
+         RoomPost roomPost = RoomPost.builder()
+                 .user(user)
+                 .title(requestDto.getTitle())
+                 .body(requestDto.getBody())
+                 .type(requestDto.getType())
+                 .status(getInitialPostStatus(requestDto.getType()))
+                 .build();
+    }
+
+
+}

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomBoard.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomBoard.java
@@ -1,4 +1,4 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.room.entity.Room;
 import jakarta.persistence.*;

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomBoard.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomBoard.java
@@ -2,27 +2,41 @@ package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.room.entity.Room;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class RoomBoard {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @OneToMany(mappedBy = "roomBoard", cascade = CascadeType.ALL)
-    private List<RoomPost> roomPostList;
+    private List<RoomPost> roomPostList = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "room_id")
     private Room room;
 
     private String name;
+
+    public void addRoomPost(RoomPost roomPost) {
+        this.roomPostList.add(roomPost);
+        roomPost.setRoomBoard(this);
+    }
+
+    public void setRoom(Room room) {
+        this.room = room;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
 
 }

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomComment.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomComment.java
@@ -1,9 +1,7 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
-import gaji.service.domain.enums.RoomAlarmTypeEnum;
 import gaji.service.domain.enums.UserAlarmTypeEnum;
-import gaji.service.domain.studyMate.StudyMate;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomCommentLikes.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomCommentLikes.java
@@ -1,4 +1,4 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
 import jakarta.persistence.*;
@@ -9,17 +9,16 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomPostBookmark {
-
+public class RoomCommentLikes {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+    @JoinColumn(name = "comment_id")
+    private RoomComment roomComment;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "room_id")
-    private RoomPost roomPost;
+    @JoinColumn(name = "user_id")
+    private User user;
 }

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomPost.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomPost.java
@@ -5,6 +5,7 @@ import gaji.service.domain.enums.PostStatusEnum;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,11 +50,9 @@ public class RoomPost {
     private int likes;
     private int bookmarks;
 
+    private LocalDateTime postTime;
     //첨부파일
     private String file;
-
-    @Enumerated(EnumType.STRING)
-    private PostStatusEnum postStatusEnum;
 
     private int weeks;
 }

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomPost.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomPost.java
@@ -1,7 +1,6 @@
 package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
-import gaji.service.domain.enums.PostStatusEnum;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -46,13 +45,19 @@ public class RoomPost {
     private List<RoomPostFile> roomPostFileList  = new ArrayList<>() ;
 
     //erd 설계에는 없지만 추가
-    private int views;
-    private int likes;
-    private int bookmarks;
+    private int viewCount;
+    private int likeCount;
+    private int bookmarkCount;
 
     private LocalDateTime postTime;
-    //첨부파일
-    private String file;
 
-    private int weeks;
+    @PrePersist
+    public void prePersist() {
+        this.viewCount = 0;
+        this.likeCount = 0;
+        this.bookmarkCount = 0;
+    }
+    public void setRoomBoard(RoomBoard roomBoard) {
+        this.roomBoard = roomBoard;
+    }
 }

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomPost.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomPost.java
@@ -1,11 +1,9 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
 import gaji.service.domain.enums.PostStatusEnum;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -13,6 +11,8 @@ import java.util.List;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class RoomPost {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomPostBookmark.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomPostBookmark.java
@@ -1,4 +1,4 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
 import jakarta.persistence.*;
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomPostLikes {
+public class RoomPostBookmark {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -19,6 +20,6 @@ public class RoomPostLikes {
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
+    @JoinColumn(name = "room_id")
     private RoomPost roomPost;
 }

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomPostFile.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomPostFile.java
@@ -1,7 +1,6 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
-import gaji.service.domain.enums.ReportPostTypeEnum;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,21 +9,19 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomPostReport {
+public class RoomPostFile {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "post_id")
     private RoomPost roomPost;
 
-    @Enumerated(EnumType.STRING)
-    private ReportPostTypeEnum reportPostTypeEnum;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
 
-    private String description;
+    private String path;
+
 }

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomPostLikes.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomPostLikes.java
@@ -1,7 +1,6 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
-import gaji.service.domain.studyMate.StudyMate;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -10,16 +9,16 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomCommentLikes {
+public class RoomPostLikes {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "comment_id")
-    private RoomComment roomComment;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private RoomPost roomPost;
 }

--- a/src/main/java/gaji/service/domain/roomPost/entity/RoomPostReport.java
+++ b/src/main/java/gaji/service/domain/roomPost/entity/RoomPostReport.java
@@ -1,6 +1,7 @@
-package gaji.service.domain.roomPost;
+package gaji.service.domain.roomPost.entity;
 
 import gaji.service.domain.User;
+import gaji.service.domain.enums.ReportPostTypeEnum;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -9,19 +10,21 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class RoomPostFile {
+public class RoomPostReport {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "post_id")
-    private RoomPost roomPost;
-
-    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    private String path;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private RoomPost roomPost;
 
+    @Enumerated(EnumType.STRING)
+    private ReportPostTypeEnum reportPostTypeEnum;
+
+    private String description;
 }

--- a/src/main/java/gaji/service/domain/roomPost/repository/RoomBoardRepository.java
+++ b/src/main/java/gaji/service/domain/roomPost/repository/RoomBoardRepository.java
@@ -1,0 +1,12 @@
+package gaji.service.domain.roomPost.repository;
+
+import gaji.service.domain.roomPost.entity.RoomBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface RoomBoardRepository extends JpaRepository<RoomBoard, Long> {
+    Optional<RoomBoard> findByRoomId(Long roomId);
+}

--- a/src/main/java/gaji/service/domain/roomPost/repository/RoomPostRepository.java
+++ b/src/main/java/gaji/service/domain/roomPost/repository/RoomPostRepository.java
@@ -1,0 +1,9 @@
+package gaji.service.domain.roomPost.repository;
+
+import gaji.service.domain.roomPost.entity.RoomPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RoomPostRepository extends JpaRepository<RoomPost, Long> {
+}

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandService.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandService.java
@@ -1,0 +1,11 @@
+package gaji.service.domain.roomPost.service;
+
+import gaji.service.domain.roomPost.entity.RoomPost;
+import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
+import jakarta.transaction.Transactional;
+
+public interface RoomPostCommandService {
+    @Transactional
+    RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto);
+
+}

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandService.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandService.java
@@ -5,7 +5,6 @@ import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
 import jakarta.transaction.Transactional;
 
 public interface RoomPostCommandService {
-    @Transactional
     RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto);
 
 }

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -12,6 +12,7 @@ import gaji.service.domain.roomPost.entity.RoomPost;
 import gaji.service.domain.roomPost.repository.RoomBoardRepository;
 import gaji.service.domain.roomPost.repository.RoomPostRepository;
 import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
+import gaji.service.domain.studyMate.repository.StudyMateRepository;
 import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,7 @@ public class RoomPostCommandServiceImpl implements RoomPostCommandService {
     private final RoomPostRepository roomPostRepository;
     private final RoomBoardRepository roomBoardRepository;
     private final RoomRepository roomRepository;
+    private final StudyMateRepository studyMateRepository;
 
     @Override
     public RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto) {
@@ -33,6 +35,10 @@ public class RoomPostCommandServiceImpl implements RoomPostCommandService {
         // 스터디룸 확인
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new RestApiException(RoomErrorStatus._ROOM_NOT_FOUND));
+
+        // 사용자가 해당 스터디룸에 참여하고 있는지 확인
+        studyMateRepository.findByUserIdAndRoomId(user.getId(), roomId)
+                .orElseThrow(() -> new RestApiException(RoomErrorStatus._USER_NOT_IN_ROOM));
 
         // 스터디룸 게시판 확인 또는 생성
         RoomBoard roomBoard = roomBoardRepository.findByRoomId(roomId)

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -15,6 +15,7 @@ import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
 import gaji.service.domain.studyMate.repository.StudyMateRepository;
 import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.global.exception.RestApiException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -27,6 +28,7 @@ public class RoomPostCommandServiceImpl implements RoomPostCommandService {
     private final RoomRepository roomRepository;
     private final StudyMateRepository studyMateRepository;
 
+    @Transactional
     @Override
     public RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto) {
         User user = userRepository.findById(userId)

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -5,6 +5,7 @@ import gaji.service.domain.post.code.PostErrorStatus;
 import gaji.service.domain.room.code.RoomErrorStatus;
 import gaji.service.domain.room.entity.Room;
 import gaji.service.domain.room.repository.RoomRepository;
+import gaji.service.domain.room.service.RoomQueryService;
 import gaji.service.domain.roomPost.code.RoomPostErrorStatus;
 import gaji.service.domain.roomPost.converter.RoomPostConverter;
 import gaji.service.domain.roomPost.entity.RoomBoard;
@@ -28,13 +29,14 @@ import org.springframework.stereotype.Service;
 public class RoomPostCommandServiceImpl implements RoomPostCommandService {
     private final RoomPostRepository roomPostRepository;
     private final RoomBoardRepository roomBoardRepository;
-    private final RoomRepository roomRepository;
     private final StudyMateRepository studyMateRepository;
     private final UserQueryService userQueryService;
-
+    private final RoomQueryService roomQueryService;
     @Override
     public RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto) {
         User user = userQueryService.findUserById(userId);
+        Room room = roomQueryService.findRoomById(roomId);
+
 
 
 

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -13,7 +13,9 @@ import gaji.service.domain.roomPost.entity.RoomPost;
 import gaji.service.domain.roomPost.repository.RoomBoardRepository;
 import gaji.service.domain.roomPost.repository.RoomPostRepository;
 import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
+import gaji.service.domain.studyMate.code.StudyMateErrorStatus;
 import gaji.service.domain.studyMate.repository.StudyMateRepository;
+import gaji.service.domain.studyMate.service.StudyMateQueryService;
 import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.domain.user.service.UserCommandService;
 import gaji.service.domain.user.service.UserQueryService;
@@ -32,17 +34,13 @@ public class RoomPostCommandServiceImpl implements RoomPostCommandService {
     private final StudyMateRepository studyMateRepository;
     private final UserQueryService userQueryService;
     private final RoomQueryService roomQueryService;
+    private final StudyMateQueryService studyMateQueryService;
+
     @Override
     public RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto) {
         User user = userQueryService.findUserById(userId);
         Room room = roomQueryService.findRoomById(roomId);
-
-
-
-
-        // 사용자가 해당 스터디룸에 참여하고 있는지 확인
-        studyMateRepository.findByUserIdAndRoomId(user.getId(), roomId)
-                .orElseThrow(() -> new RestApiException(RoomErrorStatus._USER_NOT_IN_ROOM));
+        studyMateQueryService.findByUserIdAndRoomId(user.getId(), roomId);
 
         // 스터디룸 게시판 확인 또는 생성
         RoomBoard roomBoard = roomBoardRepository.findByRoomId(roomId)

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -1,52 +1,58 @@
 package gaji.service.domain.roomPost.service;
 
 import gaji.service.domain.User;
-import gaji.service.domain.common.converter.HashtagConverter;
-import gaji.service.domain.common.entity.Hashtag;
-import gaji.service.domain.common.entity.SelectHashtag;
 import gaji.service.domain.post.code.PostErrorStatus;
 import gaji.service.domain.room.code.RoomErrorStatus;
 import gaji.service.domain.room.entity.Room;
 import gaji.service.domain.room.repository.RoomRepository;
-import gaji.service.domain.roomPost.entity.RoomPost;
+import gaji.service.domain.roomPost.code.RoomPostErrorStatus;
 import gaji.service.domain.roomPost.converter.RoomPostConverter;
+import gaji.service.domain.roomPost.entity.RoomBoard;
+import gaji.service.domain.roomPost.entity.RoomPost;
+import gaji.service.domain.roomPost.repository.RoomBoardRepository;
 import gaji.service.domain.roomPost.repository.RoomPostRepository;
 import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
-import gaji.service.domain.studyMate.repository.StudyMateRepository;
 import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.List;
-
 @Service
 @RequiredArgsConstructor
 public class RoomPostCommandServiceImpl implements RoomPostCommandService {
     private final UserRepository userRepository;
-    private final RoomRepository roomRepository;
-    private final StudyMateRepository studyMateRepository;
     private final RoomPostRepository roomPostRepository;
-
+    private final RoomBoardRepository roomBoardRepository;
+    private final RoomRepository roomRepository;
 
     @Override
     public RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RestApiException(PostErrorStatus._USER_NOT_FOUND));
 
-        // 스터디룸 존재 여부 확인
+        // 스터디룸 확인
         Room room = roomRepository.findById(roomId)
                 .orElseThrow(() -> new RestApiException(RoomErrorStatus._ROOM_NOT_FOUND));
 
-        // 사용자가 해당 스터디룸에 참여하고 있는지 확인
-        studyMateRepository.findByUserIdAndRoomId(user.getId(), roomId)
-                .orElseThrow(() -> new RestApiException(RoomErrorStatus._USER_NOT_IN_ROOM));
+        // 스터디룸 게시판 확인 또는 생성
+        RoomBoard roomBoard = roomBoardRepository.findByRoomId(roomId)
+                .orElseGet(() -> {
+                    RoomBoard newRoomBoard = RoomBoard.builder()
+                            .room(room)
+                            .name(room.getName())
+                            .build();
+                    return roomBoardRepository.save(newRoomBoard);
+                });
 
-        RoomPost roomPost = RoomPostConverter.toPost(requestDto,user);
-        roomPostRepository.save(roomPost);
+        // RoomPost 생성 및 저장
+        RoomPost roomPost = RoomPostConverter.toPost(requestDto, user, roomBoard);
+        roomPost = roomPostRepository.save(roomPost);
+
+        // RoomBoard에 새로운 RoomPost 추가
+        roomBoard.addRoomPost(roomPost);
+        roomBoardRepository.save(roomBoard);
 
         return roomPost;
-
     }
 
 }

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -1,12 +1,16 @@
 package gaji.service.domain.roomPost.service;
 
 import gaji.service.domain.User;
+import gaji.service.domain.common.converter.HashtagConverter;
+import gaji.service.domain.common.entity.Hashtag;
+import gaji.service.domain.common.entity.SelectHashtag;
 import gaji.service.domain.post.code.PostErrorStatus;
 import gaji.service.domain.room.code.RoomErrorStatus;
 import gaji.service.domain.room.entity.Room;
 import gaji.service.domain.room.repository.RoomRepository;
 import gaji.service.domain.roomPost.entity.RoomPost;
 import gaji.service.domain.roomPost.converter.RoomPostConverter;
+import gaji.service.domain.roomPost.repository.RoomPostRepository;
 import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
 import gaji.service.domain.studyMate.repository.StudyMateRepository;
 import gaji.service.domain.user.repository.UserRepository;
@@ -14,12 +18,15 @@ import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class RoomPostCommandServiceImpl implements RoomPostCommandService {
     private final UserRepository userRepository;
     private final RoomRepository roomRepository;
     private final StudyMateRepository studyMateRepository;
+    private final RoomPostRepository roomPostRepository;
 
 
     @Override
@@ -35,7 +42,10 @@ public class RoomPostCommandServiceImpl implements RoomPostCommandService {
         studyMateRepository.findByUserIdAndRoomId(user.getId(), roomId)
                 .orElseThrow(() -> new RestApiException(RoomErrorStatus._USER_NOT_IN_ROOM));
 
-        RoomPost = RoomPostConverter.toPost(requestDto,user);
+        RoomPost roomPost = RoomPostConverter.toPost(requestDto,user);
+        roomPostRepository.save(roomPost);
+
+        return roomPost;
 
     }
 

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -14,6 +14,9 @@ import gaji.service.domain.roomPost.repository.RoomPostRepository;
 import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
 import gaji.service.domain.studyMate.repository.StudyMateRepository;
 import gaji.service.domain.user.repository.UserRepository;
+import gaji.service.domain.user.service.UserCommandService;
+import gaji.service.domain.user.service.UserQueryService;
+import gaji.service.domain.user.service.UserQueryServiceImpl;
 import gaji.service.global.exception.RestApiException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -21,22 +24,19 @@ import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class RoomPostCommandServiceImpl implements RoomPostCommandService {
-    private final UserRepository userRepository;
     private final RoomPostRepository roomPostRepository;
     private final RoomBoardRepository roomBoardRepository;
     private final RoomRepository roomRepository;
     private final StudyMateRepository studyMateRepository;
+    private final UserQueryService userQueryService;
 
-    @Transactional
     @Override
     public RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new RestApiException(PostErrorStatus._USER_NOT_FOUND));
+        User user = userQueryService.findUserById(userId);
 
-        // 스터디룸 확인
-        Room room = roomRepository.findById(roomId)
-                .orElseThrow(() -> new RestApiException(RoomErrorStatus._ROOM_NOT_FOUND));
+
 
         // 사용자가 해당 스터디룸에 참여하고 있는지 확인
         studyMateRepository.findByUserIdAndRoomId(user.getId(), roomId)

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -1,0 +1,42 @@
+package gaji.service.domain.roomPost.service;
+
+import gaji.service.domain.User;
+import gaji.service.domain.post.code.PostErrorStatus;
+import gaji.service.domain.room.code.RoomErrorStatus;
+import gaji.service.domain.room.entity.Room;
+import gaji.service.domain.room.repository.RoomRepository;
+import gaji.service.domain.roomPost.entity.RoomPost;
+import gaji.service.domain.roomPost.converter.RoomPostConverter;
+import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
+import gaji.service.domain.studyMate.repository.StudyMateRepository;
+import gaji.service.domain.user.repository.UserRepository;
+import gaji.service.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RoomPostCommandServiceImpl implements RoomPostCommandService {
+    private final UserRepository userRepository;
+    private final RoomRepository roomRepository;
+    private final StudyMateRepository studyMateRepository;
+
+
+    @Override
+    public RoomPost createRoomPost(Long roomId, Long userId, RoomPostRequestDto.RoomPostDto requestDto) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(PostErrorStatus._USER_NOT_FOUND));
+
+        // 스터디룸 존재 여부 확인
+        Room room = roomRepository.findById(roomId)
+                .orElseThrow(() -> new RestApiException(RoomErrorStatus._ROOM_NOT_FOUND));
+
+        // 사용자가 해당 스터디룸에 참여하고 있는지 확인
+        studyMateRepository.findByUserIdAndRoomId(user.getId(), roomId)
+                .orElseThrow(() -> new RestApiException(RoomErrorStatus._USER_NOT_IN_ROOM));
+
+        RoomPost = RoomPostConverter.toPost(requestDto,user);
+
+    }
+
+}

--- a/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomPost/service/RoomPostCommandServiceImpl.java
@@ -53,7 +53,7 @@ public class RoomPostCommandServiceImpl implements RoomPostCommandService {
                 });
 
         // RoomPost 생성 및 저장
-        RoomPost roomPost = RoomPostConverter.toPost(requestDto, user, roomBoard);
+        RoomPost roomPost = RoomPostConverter.toRoomPost(requestDto, user, roomBoard);
         roomPost = roomPostRepository.save(roomPost);
 
         // RoomBoard에 새로운 RoomPost 추가

--- a/src/main/java/gaji/service/domain/roomPost/web/controller/RoomPostController.java
+++ b/src/main/java/gaji/service/domain/roomPost/web/controller/RoomPostController.java
@@ -16,12 +16,15 @@ public class RoomPostController {
 
     private final RoomPostCommandServiceImpl roomBoardCommandService;
 
-    @PostMapping("/boards/{roomId}/{userId}"/*userId는 테스트를 위한 것, 추후에 삭제 예정*/)
-    @Operation(summary = "스터디룸 게시글 등록 API",description = "스터디룸의 게시글을 등록하는 API입니다. room의 id가 존재하는지, 스터디에 참혀하고 있는 user인지 검증합니다.")
-    public BaseResponse<Long> RoomBoardController(@PathVariable Long userId/*하드 코딩용, 추후 삭제*/, @RequestBody @Valid RoomPostRequestDto.RoomPostDto requestDto, @PathVariable Long roomId){
-        //Long userId = getUserIdFromToken(token);
-        RoomPost assignment = roomBoardCommandService.createRoomPost(roomId,userId,requestDto);
-        return BaseResponse.onSuccess(assignment.getId());
+    @PostMapping(value = "/post/{roomId}/{userId}")
+    @Operation(summary = "스터디룸 게시글 등록 API", description = "스터디룸의 게시글을 등록하는 API입니다. room의 id가 존재하는지, 스터디에 참여하고 있는 user인지 검증합니다.")
+    public BaseResponse<Long> RoomBoardController(
+            @PathVariable Long userId,
+            @PathVariable Long roomId,
+            @RequestBody @Valid RoomPostRequestDto.RoomPostDto requestDto) {
+        RoomPost roomPost = roomBoardCommandService.createRoomPost(roomId, userId, requestDto);
+        return BaseResponse.onSuccess(roomPost.getId());
     }
-
 }
+
+

--- a/src/main/java/gaji/service/domain/roomPost/web/controller/RoomPostController.java
+++ b/src/main/java/gaji/service/domain/roomPost/web/controller/RoomPostController.java
@@ -14,17 +14,6 @@ import org.springframework.web.bind.annotation.*;
 @RequestMapping("/api/studyRooms")
 public class RoomPostController {
 
-    private final RoomPostCommandServiceImpl roomBoardCommandService;
-
-    @PostMapping(value = "/post/{roomId}/{userId}")
-    @Operation(summary = "스터디룸 게시글 등록 API", description = "스터디룸의 게시글을 등록하는 API입니다. room의 id가 존재하는지, 스터디에 참여하고 있는 user인지 검증합니다.")
-    public BaseResponse<Long> RoomBoardController(
-            @PathVariable Long userId,
-            @PathVariable Long roomId,
-            @RequestBody @Valid RoomPostRequestDto.RoomPostDto requestDto) {
-        RoomPost roomPost = roomBoardCommandService.createRoomPost(roomId, userId, requestDto);
-        return BaseResponse.onSuccess(roomPost.getId());
-    }
 }
 
 

--- a/src/main/java/gaji/service/domain/roomPost/web/controller/RoomPostController.java
+++ b/src/main/java/gaji/service/domain/roomPost/web/controller/RoomPostController.java
@@ -1,0 +1,27 @@
+package gaji.service.domain.roomPost.web.controller;
+
+import gaji.service.domain.roomPost.entity.RoomPost;
+import gaji.service.domain.roomPost.service.RoomPostCommandServiceImpl;
+import gaji.service.domain.roomPost.web.dto.RoomPostRequestDto;
+import gaji.service.global.base.BaseResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/studyRooms")
+public class RoomPostController {
+
+    private final RoomPostCommandServiceImpl roomBoardCommandService;
+
+    @PostMapping("/boards/{roomId}/{userId}"/*userId는 테스트를 위한 것, 추후에 삭제 예정*/)
+    @Operation(summary = "스터디룸 게시글 등록 API",description = "스터디룸의 게시글을 등록하는 API입니다. room의 id가 존재하는지, 스터디에 참혀하고 있는 user인지 검증합니다.")
+    public BaseResponse<Long> RoomBoardController(@PathVariable Long userId/*하드 코딩용, 추후 삭제*/, @RequestBody @Valid RoomPostRequestDto.RoomPostDto requestDto, @PathVariable Long roomId){
+        //Long userId = getUserIdFromToken(token);
+        RoomPost assignment = roomBoardCommandService.createRoomPost(roomId,userId,requestDto);
+        return BaseResponse.onSuccess(assignment.getId());
+    }
+
+}

--- a/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostRequestDto.java
+++ b/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostRequestDto.java
@@ -1,0 +1,40 @@
+package gaji.service.domain.roomPost.web.dto;
+
+import gaji.service.domain.common.annotation.CheckHashtagListElement;
+import gaji.service.domain.enums.PostTypeEnum;
+import gaji.service.domain.post.annotation.ExistPostType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+public class RoomPostRequestDto {
+
+    @Schema(description = "스터디 게시글 DTO")
+    @Getter
+    @RequiredArgsConstructor
+    public static class RoomPostDto {
+        @Schema(description = "게시글 제목")
+        @NotBlank(message = "제목을 입력해주세요.")
+        private final String title;
+
+        @Schema(description = "게시글 본문")
+        @NotBlank(message = "게시글 본문을 입력해주세요.")
+        private final String body;
+
+        @Schema(description = "Enum 종류(프로젝트 모집, 질문, 블로그)")
+        @ExistPostType
+        private final PostTypeEnum type;
+
+        @Schema(description = "태그 리스트")
+        @CheckHashtagListElement
+        private final List<String> hashtagList = new ArrayList<>();
+    }
+
+
+
+}

--- a/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostRequestDto.java
+++ b/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostRequestDto.java
@@ -1,15 +1,9 @@
 package gaji.service.domain.roomPost.web.dto;
 
-import gaji.service.domain.common.annotation.CheckHashtagListElement;
-import gaji.service.domain.enums.PostTypeEnum;
-import gaji.service.domain.post.annotation.ExistPostType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-
-import java.util.ArrayList;
-import java.util.List;
 
 
 public class RoomPostRequestDto {
@@ -26,9 +20,6 @@ public class RoomPostRequestDto {
         @NotBlank(message = "게시글 본문을 입력해주세요.")
         private final String body;
 
-
     }
-
-
 
 }

--- a/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostRequestDto.java
+++ b/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostRequestDto.java
@@ -26,13 +26,7 @@ public class RoomPostRequestDto {
         @NotBlank(message = "게시글 본문을 입력해주세요.")
         private final String body;
 
-        @Schema(description = "Enum 종류(프로젝트 모집, 질문, 블로그)")
-        @ExistPostType
-        private final PostTypeEnum type;
 
-        @Schema(description = "태그 리스트")
-        @CheckHashtagListElement
-        private final List<String> hashtagList = new ArrayList<>();
     }
 
 

--- a/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostResponseDto.java
+++ b/src/main/java/gaji/service/domain/roomPost/web/dto/RoomPostResponseDto.java
@@ -1,0 +1,16 @@
+package gaji.service.domain.roomPost.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class RoomPostResponseDto {
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CreateRoomPostDTO {
+        Long postId;
+    }
+}

--- a/src/main/java/gaji/service/domain/studyMate/code/StudyMateErrorStatus.java
+++ b/src/main/java/gaji/service/domain/studyMate/code/StudyMateErrorStatus.java
@@ -1,0 +1,32 @@
+package gaji.service.domain.studyMate.code;
+
+import gaji.service.global.exception.code.BaseCodeDto;
+import gaji.service.global.exception.code.BaseErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum StudyMateErrorStatus implements BaseErrorCodeInterface {
+    // 스터디룸 게시판
+    _USER_NOT_IN_STUDYROOM(HttpStatus.BAD_REQUEST, "StudyMateError_4001", "회원이 해당 스터디룸에 참여하고 있지 않습니다.");
+
+
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess = false;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCodeDto getErrorCode() {
+        return BaseCodeDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/gaji/service/domain/studyMate/service/StudyMateQueryService.java
+++ b/src/main/java/gaji/service/domain/studyMate/service/StudyMateQueryService.java
@@ -1,0 +1,7 @@
+package gaji.service.domain.studyMate.service;
+
+import gaji.service.domain.studyMate.StudyMate;
+
+public interface StudyMateQueryService {
+    StudyMate findByUserIdAndRoomId(Long id, Long roomId);
+}

--- a/src/main/java/gaji/service/domain/studyMate/service/StudyMateQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/studyMate/service/StudyMateQueryServiceImpl.java
@@ -1,0 +1,23 @@
+package gaji.service.domain.studyMate.service;
+
+import gaji.service.domain.studyMate.StudyMate;
+import gaji.service.domain.studyMate.code.StudyMateErrorStatus;
+import gaji.service.domain.studyMate.repository.StudyMateRepository;
+import gaji.service.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyMateQueryServiceImpl implements StudyMateQueryService {
+
+    private final StudyMateRepository studyMateRepository;
+
+    @Override
+    public StudyMate findByUserIdAndRoomId(Long userId, Long roomId) {
+        return studyMateRepository.findByUserIdAndRoomId(userId, roomId)
+                .orElseThrow(() -> new RestApiException(StudyMateErrorStatus._USER_NOT_IN_STUDYROOM));
+
+    }
+
+}

--- a/src/main/java/gaji/service/domain/user/code/UserErrorStatus.java
+++ b/src/main/java/gaji/service/domain/user/code/UserErrorStatus.java
@@ -1,0 +1,32 @@
+package gaji.service.domain.user.code;
+
+import gaji.service.global.exception.code.BaseCodeDto;
+import gaji.service.global.exception.code.BaseErrorCodeInterface;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorStatus implements BaseErrorCodeInterface {
+    // 스터디룸 게시판
+    _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_4001", "존재하지 않는 회원입니다.");
+
+
+
+    private final HttpStatus httpStatus;
+    private final boolean isSuccess = false;
+    private final String code;
+    private final String message;
+
+    @Override
+    public BaseCodeDto getErrorCode() {
+        return BaseCodeDto.builder()
+                .httpStatus(httpStatus)
+                .isSuccess(isSuccess)
+                .code(code)
+                .message(message)
+                .build();
+    }
+}

--- a/src/main/java/gaji/service/domain/user/service/UserCommandService.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandService.java
@@ -1,0 +1,4 @@
+package gaji.service.domain.user.service;
+
+public interface UserCommandService {
+}

--- a/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
@@ -1,0 +1,9 @@
+package gaji.service.domain.user.service;
+
+import gaji.service.domain.User;
+import gaji.service.domain.user.repository.UserRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class UserCommandServiceImpl implements UserCommandService {
+}

--- a/src/main/java/gaji/service/domain/user/service/UserQueryService.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryService.java
@@ -1,6 +1,12 @@
 package gaji.service.domain.user.service;
 
+import gaji.service.domain.User;
+
+import java.util.Optional;
+
 public interface UserQueryService {
 
     boolean existUserById(Long userId);
+    User findUserById(Long userId);
+
 }

--- a/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
@@ -1,9 +1,14 @@
 package gaji.service.domain.user.service;
 
+import gaji.service.domain.User;
+import gaji.service.domain.post.code.PostErrorStatus;
 import gaji.service.domain.user.repository.UserRepository;
+import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +20,10 @@ public class UserQueryServiceImpl implements UserQueryService {
     @Override
     public boolean existUserById(Long userId) {
         return userRepository.existsById(userId);
+    }
+
+    public User findUserById(Long userId){
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new RestApiException(PostErrorStatus._USER_NOT_FOUND));
     }
 }

--- a/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
@@ -2,6 +2,7 @@ package gaji.service.domain.user.service;
 
 import gaji.service.domain.User;
 import gaji.service.domain.post.code.PostErrorStatus;
+import gaji.service.domain.user.code.UserErrorStatus;
 import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,6 @@ public class UserQueryServiceImpl implements UserQueryService {
 
     public User findUserById(Long userId){
         return userRepository.findById(userId)
-                .orElseThrow(() -> new RestApiException(PostErrorStatus._USER_NOT_FOUND));
+                .orElseThrow(() -> new RestApiException(UserErrorStatus._USER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#50-StudyRoom-Post/GAJI-75 -> feature/#50-StudyRoom-Post/GAJI-75-> develop

## 변경 사항
- 스터디룸에서 게시물을 등록합니다.
- 스터디룸은 한 개의 게시판을 갖습니다.
- 한 개의 개시판이 여러 개의 게시물과 매핑이 됩니다.
- 게시판이 존재하지 않는다면 게시물이 업로드 될 떄 양방향 매핑 기법을 사용해서 게시판을 생성합니다.

## 이슈
- RoomBoar에서 List<RoomPost> rooPost List 에서 Array가 선언되지 않은 상태여서 선언했습니다.  

## 테스트 결과
### Request 
```
{
  "title": "가지",
  "body": "화이팅!"
}
```

### 200 ok
![image](https://github.com/user-attachments/assets/71468931-667c-4f13-96b1-0813c23cd2d7)


### 존재하지 않는 회원일 때
![image](https://github.com/user-attachments/assets/67d54df5-d611-4ce0-9c84-059f5f51411c)


### 존재하지 않는 스터디룸일  때
![image](https://github.com/user-attachments/assets/47bf2feb-d745-48c8-b07b-cf19c6d3a8bd)


### 참여자가 참여하고 있는 스터디룸이 아닐 때
![image](https://github.com/user-attachments/assets/86dea445-2f9f-4e7e-88c8-a1c85785aa7c)
