### PR TITLE
✨ [feature] #27 - oAuth2 소셜로그인 API 구현 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,14 @@ dependencies {
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client' //OAuth2 의존성 추가
+	implementation 'org.springframework.boot:spring-boot-starter-security' // 스프링 시큐리티 의존성 추가
+	testImplementation 'org.springframework.security:spring-security-test'
+
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3' //jwt 의존성 추가
+	implementation 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	implementation 'io.jsonwebtoken:jjwt-jackson:0.12.3'
+
 	implementation 'mysql:mysql-connector-java:8.0.33'
 }
 

--- a/src/main/java/gaji/service/config/SecurityConfig.java
+++ b/src/main/java/gaji/service/config/SecurityConfig.java
@@ -1,0 +1,99 @@
+package gaji.service.config;
+
+import gaji.service.jwt.filter.CustomLogoutFilter;
+import gaji.service.jwt.filter.JWTFilter;
+import gaji.service.jwt.filter.JWTUtil;
+import gaji.service.jwt.rpository.RefreshRepository;
+import gaji.service.jwt.service.CustomSuccessHandler;
+import gaji.service.oauth2.service.CustomOAuth2UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.authentication.logout.LogoutFilter;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomSuccessHandler customSuccessHandler;
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+
+        http
+                .cors(corsCustomizer -> corsCustomizer.configurationSource(new CorsConfigurationSource() {
+
+                    @Override
+                    public CorsConfiguration getCorsConfiguration(HttpServletRequest request) {
+
+                        CorsConfiguration configuration = new CorsConfiguration();
+
+                        configuration.setAllowedOrigins(Collections.singletonList("http://localhost:3000"));
+                        configuration.setAllowedMethods(Collections.singletonList("*"));
+                        configuration.setAllowCredentials(true);
+                        configuration.setMaxAge(3600L);
+
+                        configuration.setExposedHeaders(Collections.singletonList("Set-Cookie"));
+                        configuration.setExposedHeaders(Collections.singletonList("Authorization"));
+
+                        return configuration;
+                    }
+                }));
+        //csrf disable
+        http
+                .csrf((auth) -> auth.disable());
+
+        //From 로그인 방식 disable
+        http
+                .formLogin((auth) -> auth.disable());
+
+        //HTTP Basic 인증 방식 disable
+        http
+                .httpBasic((auth) -> auth.disable());
+
+        //JWTFilter 추가
+        http
+                .addFilterBefore(new JWTFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        http
+                .addFilterBefore(new CustomLogoutFilter(jwtUtil, refreshRepository), LogoutFilter.class);
+
+        http
+                .oauth2Login((oauth2) -> oauth2
+                        .userInfoEndpoint((userInfoEndpointConfig) -> userInfoEndpointConfig
+                                .userService(customOAuth2UserService))
+                        .successHandler(customSuccessHandler));
+
+
+
+        //oauth2
+
+
+        //경로별 인가 작업
+        http
+                .authorizeHttpRequests((auth) -> auth
+                        .requestMatchers("/","/my","/reissue").permitAll()
+                        .anyRequest().authenticated());
+
+        //세션 설정 : STATELESS
+        http
+                .sessionManagement((session) -> session
+                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+
+        return http.build();
+    }
+}

--- a/src/main/java/gaji/service/config/SecurityConfig.java
+++ b/src/main/java/gaji/service/config/SecurityConfig.java
@@ -31,6 +31,11 @@ public class SecurityConfig {
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
 
+
+    private static final String[] AUTH_WHITELIST = {
+            "/oauth2/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/reissue", "/", "/my"
+    };
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
 
@@ -86,9 +91,8 @@ public class SecurityConfig {
         //경로별 인가 작업
         http
                 .authorizeHttpRequests((auth) -> auth
-                        .requestMatchers("/","/my","/reissue").permitAll()
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
                         .anyRequest().authenticated());
-
         //세션 설정 : STATELESS
         http
                 .sessionManagement((session) -> session

--- a/src/main/java/gaji/service/domain/User.java
+++ b/src/main/java/gaji/service/domain/User.java
@@ -13,6 +13,7 @@ import gaji.service.domain.room.entity.Event;
 import gaji.service.domain.room.entity.VoiceChatUser;
 import gaji.service.domain.roomPost.*;
 import gaji.service.domain.studyMate.*;
+import gaji.service.oauth2.dto.TransferUserDTO;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -140,6 +141,59 @@ public class User extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
     private String profileImagePth;
+    private String usernameId;
+
+    public static User createUser(TransferUserDTO transferUserDTO) {
+        User user = new User();
+        user.setUsernameId(transferUserDTO.getUsernameId());
+        user.setEmail(transferUserDTO.getEmail());
+        user.setName(transferUserDTO.getName());
+        user.setRole(transferUserDTO.getRole());
+        user.setBirthday(transferUserDTO.getBirthday());
+        user.setSocialType(transferUserDTO.getSocialType());
+        user.setGender(transferUserDTO.getGender());
+        user.setStatus(transferUserDTO.getUserActive());
+        return user;
+    }
+
+    private void setStatus(UserActive userActive) {
+        this.status = userActive;
+    }
+
+    private void setGender(Gender gender) {
+        this.gender = gender;
+
+    }
+
+    private void setSocialType(SocialType socialType) {
+        this.socialType = socialType;
+    }
+
+    private void setBirthday(LocalDate birthday) {
+        this.birthday = birthday;
+    }
+
+    private void setRole(Role role) {
+        this.role = role;
+
+    }
+
+
+    public void setName(String name) {
+
+        this.name = name;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+
+    public void setUsernameId(String usernameId) {
+
+        this.usernameId = usernameId;
+    }
+
 
 
 

--- a/src/main/java/gaji/service/domain/User.java
+++ b/src/main/java/gaji/service/domain/User.java
@@ -2,10 +2,7 @@ package gaji.service.domain;
 
 import gaji.service.domain.alram.Alarm;
 import gaji.service.domain.common.entity.BaseEntity;
-import gaji.service.domain.enums.Gender;
-import gaji.service.domain.enums.Role;
-import gaji.service.domain.enums.SocialType;
-import gaji.service.domain.enums.UserActive;
+import gaji.service.domain.enums.*;
 import gaji.service.domain.message.Message;
 import gaji.service.domain.post.entity.*;
 import gaji.service.domain.recruite.*;
@@ -139,7 +136,7 @@ public class User extends BaseEntity {
     private LocalDateTime inactiveTime;
 
     @Enumerated(EnumType.STRING)
-    private Role role;
+    private ServiceRole role;
     private String profileImagePth;
     private String usernameId;
 
@@ -173,7 +170,7 @@ public class User extends BaseEntity {
         this.birthday = birthday;
     }
 
-    private void setRole(Role role) {
+    private void setRole(ServiceRole role) {
         this.role = role;
 
     }

--- a/src/main/java/gaji/service/domain/User.java
+++ b/src/main/java/gaji/service/domain/User.java
@@ -125,7 +125,7 @@ public class User extends BaseEntity {
     private String nickname;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Gender gender;
 
     private LocalDate birthday;

--- a/src/main/java/gaji/service/domain/enums/Gender.java
+++ b/src/main/java/gaji/service/domain/enums/Gender.java
@@ -1,5 +1,5 @@
 package gaji.service.domain.enums;
 
 public enum Gender {
-    MALE, FEMALE
+    MALE, FEMALE, UNKNOWN
 }

--- a/src/main/java/gaji/service/domain/enums/ServiceRole.java
+++ b/src/main/java/gaji/service/domain/enums/ServiceRole.java
@@ -1,0 +1,5 @@
+package gaji.service.domain.enums;
+
+public enum ServiceRole {
+    ROLE_USER,ROOT
+}

--- a/src/main/java/gaji/service/domain/enums/ServiceRole.java
+++ b/src/main/java/gaji/service/domain/enums/ServiceRole.java
@@ -1,5 +1,5 @@
 package gaji.service.domain.enums;
 
 public enum ServiceRole {
-    ROLE_USER,ROOT
+    ROLE_USER,ROLE_ROOT
 }

--- a/src/main/java/gaji/service/domain/user/repository/UserRepository.java
+++ b/src/main/java/gaji/service/domain/user/repository/UserRepository.java
@@ -4,4 +4,6 @@ import gaji.service.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
+    User findByUsernameId(String username);
+
 }

--- a/src/main/java/gaji/service/jwt/config/CorsMvcConfig.java
+++ b/src/main/java/gaji/service/jwt/config/CorsMvcConfig.java
@@ -1,0 +1,17 @@
+package gaji.service.jwt.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsMvcConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addCorsMappings(CorsRegistry corsRegistry) {
+
+        corsRegistry.addMapping("/**")
+                .exposedHeaders("Set-Cookie")
+                .allowedOrigins("http://localhost:3000");
+    }
+}

--- a/src/main/java/gaji/service/jwt/controller/ReissueController.java
+++ b/src/main/java/gaji/service/jwt/controller/ReissueController.java
@@ -1,0 +1,25 @@
+package gaji.service.jwt.controller;
+
+import gaji.service.jwt.service.ReissueService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+
+public class ReissueController {
+
+    private final ReissueService reissueService;
+
+
+    @PostMapping("/reissue")
+    public ResponseEntity<?> reissue(HttpServletRequest request, HttpServletResponse response) {
+        reissueService.reissue(request,response);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/gaji/service/jwt/dto/TokenUserDTO.java
+++ b/src/main/java/gaji/service/jwt/dto/TokenUserDTO.java
@@ -1,0 +1,11 @@
+package gaji.service.jwt.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TokenUserDTO {
+    private String usernameId;
+    private String role;
+}

--- a/src/main/java/gaji/service/jwt/entity/RefreshEntity.java
+++ b/src/main/java/gaji/service/jwt/entity/RefreshEntity.java
@@ -1,0 +1,22 @@
+package gaji.service.jwt.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Getter;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+public class RefreshEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String username;
+    private String refresh;
+    private String expiration;
+}

--- a/src/main/java/gaji/service/jwt/filter/CustomLogoutFilter.java
+++ b/src/main/java/gaji/service/jwt/filter/CustomLogoutFilter.java
@@ -1,0 +1,107 @@
+package gaji.service.jwt.filter;
+
+import gaji.service.jwt.rpository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.filter.GenericFilterBean;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class CustomLogoutFilter extends GenericFilterBean {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
+    }
+
+    private void doFilter(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws IOException, ServletException {
+
+        //path and method verify
+        String requestUri = request.getRequestURI();
+        if (!requestUri.matches("^\\/oauth2\\/logout$")){
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+        String requestMethod = request.getMethod();
+        if (!requestMethod.equals("POST")) {
+
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+
+        //refresh null check
+        if (refresh == null) {
+
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+        if (!category.equals("refresh")) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
+            return;
+        }
+
+        //로그아웃 진행
+        //Refresh 토큰 DB에서 제거
+        refreshRepository.deleteByRefresh(refresh);
+
+        //Refresh 토큰 Cookie 값 0
+        Cookie cookie = new Cookie("refresh", null);
+        cookie.setMaxAge(0);
+        cookie.setPath("/");
+
+        response.addCookie(cookie);
+        response.setStatus(HttpServletResponse.SC_OK);
+    }
+}

--- a/src/main/java/gaji/service/jwt/filter/JWTFilter.java
+++ b/src/main/java/gaji/service/jwt/filter/JWTFilter.java
@@ -1,6 +1,7 @@
 package gaji.service.jwt.filter;
 
 import gaji.service.domain.enums.Role;
+import gaji.service.domain.enums.ServiceRole;
 import gaji.service.oauth2.dto.CustomOAuth2User;
 import gaji.service.oauth2.dto.OAuthUserDTO;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -71,7 +72,7 @@ public class JWTFilter extends OncePerRequestFilter {
 
         OAuthUserDTO oAuthUserDTO = new OAuthUserDTO();
         oAuthUserDTO.setUsernameId(username);
-        oAuthUserDTO.setRole(Role.valueOf(role));
+        oAuthUserDTO.setRole(ServiceRole.valueOf(role));
         CustomOAuth2User customUserDetails = new CustomOAuth2User(oAuthUserDTO);
 
         Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());

--- a/src/main/java/gaji/service/jwt/filter/JWTFilter.java
+++ b/src/main/java/gaji/service/jwt/filter/JWTFilter.java
@@ -1,0 +1,82 @@
+package gaji.service.jwt.filter;
+
+import gaji.service.domain.enums.Role;
+import gaji.service.oauth2.dto.CustomOAuth2User;
+import gaji.service.oauth2.dto.OAuthUserDTO;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+
+@RequiredArgsConstructor
+public class JWTFilter extends OncePerRequestFilter {
+
+    private final JWTUtil jwtUtil;
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String accessToken = request.getHeader("access");
+
+// 토큰이 없다면 다음 필터로 넘김
+        if (accessToken == null) {
+
+            filterChain.doFilter(request, response);
+
+            return;
+        }
+
+// 토큰 만료 여부 확인, 만료시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e) {
+
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("access token expired");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+// 토큰이 access인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(accessToken);
+
+        if (!category.equals("access")) {
+
+            //response body
+            PrintWriter writer = response.getWriter();
+            writer.print("invalid access token");
+
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+// username, role 값을 획득
+        String username = jwtUtil.getUsername(accessToken);
+        String role = jwtUtil.getRole(accessToken);
+
+        OAuthUserDTO oAuthUserDTO = new OAuthUserDTO();
+        oAuthUserDTO.setUsernameId(username);
+        oAuthUserDTO.setRole(Role.valueOf(role));
+        CustomOAuth2User customUserDetails = new CustomOAuth2User(oAuthUserDTO);
+
+        Authentication authToken = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authToken);
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/gaji/service/jwt/filter/JWTUtil.java
+++ b/src/main/java/gaji/service/jwt/filter/JWTUtil.java
@@ -1,0 +1,54 @@
+package gaji.service.jwt.filter;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JWTUtil {
+
+    private SecretKey secretKey;
+
+    public JWTUtil(@Value("${spring.jwt.secret}")String secret) {
+
+
+        secretKey = new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public String getUsername(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("username", String.class);
+    }
+
+    public String getRole(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("role", String.class);
+    }
+
+    public Boolean isExpired(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().getExpiration().before(new Date());
+    }
+
+    public String getCategory(String token) {
+
+        return Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token).getPayload().get("category", String.class);
+    }
+
+    public String createJwt(String category, String username, String role, Long expiredMs) {
+
+        return Jwts.builder()
+                .claim("category", category)
+                .claim("username", username)
+                .claim("role", role)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+}

--- a/src/main/java/gaji/service/jwt/rpository/RefreshRepository.java
+++ b/src/main/java/gaji/service/jwt/rpository/RefreshRepository.java
@@ -1,6 +1,5 @@
 package gaji.service.jwt.rpository;
 
-import gaji.service.domain.User;
 import gaji.service.jwt.entity.RefreshEntity;
 import jakarta.transaction.Transactional;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -17,6 +16,4 @@ public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
     RefreshEntity findByUsername(String usernameId);
 
     Boolean existsByUsername(String refresh);
-    User findByUsernameId(String username);
-
 }

--- a/src/main/java/gaji/service/jwt/rpository/RefreshRepository.java
+++ b/src/main/java/gaji/service/jwt/rpository/RefreshRepository.java
@@ -1,0 +1,22 @@
+package gaji.service.jwt.rpository;
+
+import gaji.service.domain.User;
+import gaji.service.jwt.entity.RefreshEntity;
+import jakarta.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RefreshRepository extends JpaRepository<RefreshEntity, Long> {
+
+    Boolean existsByRefresh(String refresh);
+
+    @Transactional
+    void deleteByRefresh(String refresh);
+
+    RefreshEntity findByUsername(String usernameId);
+
+    Boolean existsByUsername(String refresh);
+    User findByUsernameId(String username);
+
+}

--- a/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
+++ b/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
@@ -1,0 +1,87 @@
+package gaji.service.jwt.service;
+
+import gaji.service.jwt.entity.RefreshEntity;
+import gaji.service.jwt.filter.JWTUtil;
+import gaji.service.jwt.rpository.RefreshRepository;
+import gaji.service.oauth2.dto.CustomOAuth2User;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.Iterator;
+
+@Component
+
+public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+
+    private final JWTUtil jwtUtil;
+    private final RefreshRepository refreshRepository;
+
+    public CustomSuccessHandler(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
+        this.jwtUtil = jwtUtil;
+        this.refreshRepository = refreshRepository;
+    }
+
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException, IOException {
+        //OAuth2User
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        String usernameId = customUserDetails.getName();
+        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+        GrantedAuthority auth = iterator.next();
+        String role = auth.getAuthority();
+
+        //토큰 생성
+        String access = jwtUtil.createJwt("access", usernameId, role, 600000L);
+        String refresh = jwtUtil.createJwt("refresh", usernameId, role, 86400000L);
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByUsername(usernameId);
+        if (!isExist) {
+            addRefreshEntity(usernameId, refresh, 86400000L);
+        }
+
+
+        //응답 설정
+        response.setHeader("access", access);
+        response.addCookie(createCookie("refresh", refresh));
+        response.setStatus(HttpStatus.OK.value());
+        response.sendRedirect("http://localhost:8080/my");
+
+    }
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(60*60*60);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+
+    private void addRefreshEntity(String username, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+}

--- a/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
+++ b/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
@@ -1,87 +1,163 @@
+//package gaji.service.jwt.service;
+//
+//import gaji.service.jwt.entity.RefreshEntity;
+//import gaji.service.jwt.filter.JWTUtil;
+//import gaji.service.jwt.rpository.RefreshRepository;
+//import gaji.service.oauth2.dto.CustomOAuth2User;
+//import jakarta.servlet.ServletException;
+//import jakarta.servlet.http.Cookie;
+//import jakarta.servlet.http.HttpServletRequest;
+//import jakarta.servlet.http.HttpServletResponse;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.security.core.Authentication;
+//import org.springframework.security.core.GrantedAuthority;
+//import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+//import org.springframework.stereotype.Component;
+//
+//import java.io.IOException;
+//import java.util.Collection;
+//import java.util.Date;
+//import java.util.Iterator;
+//
+//@Component
+//
+//public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+//
+//    private final JWTUtil jwtUtil;
+//    private final RefreshRepository refreshRepository;
+//
+//    public CustomSuccessHandler(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
+//        this.jwtUtil = jwtUtil;
+//        this.refreshRepository = refreshRepository;
+//    }
+//
+//
+//    @Override
+//    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException, IOException {
+//        //OAuth2User
+//        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+//
+//        String usernameId = customUserDetails.getName();
+//        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
+//        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
+//        GrantedAuthority auth = iterator.next();
+//        String role = auth.getAuthority();
+//
+//        //토큰 생성
+//        String access = jwtUtil.createJwt("access", usernameId, role, 600000L);
+//        String refresh = jwtUtil.createJwt("refresh", usernameId, role, 86400000L);
+//
+//        //DB에 저장되어 있는지 확인
+//        Boolean isExist = refreshRepository.existsByUsername(usernameId);
+//        if (!isExist) {
+//            addRefreshEntity(usernameId, refresh, 86400000L);
+//        }
+//
+//
+//        //응답 설정
+//        response.setHeader("access", access);
+//        response.addCookie(createCookie("refresh", refresh));
+//        response.setStatus(HttpStatus.OK.value());
+//        response.sendRedirect("http://localhost:8080/my");
+//
+//    }
+//
+//    private Cookie createCookie(String key, String value) {
+//
+//        Cookie cookie = new Cookie(key, value);
+//        cookie.setMaxAge(60*60*60);
+//        cookie.setSecure(true);
+//        cookie.setPath("/");
+//        cookie.setHttpOnly(true);
+//
+//        return cookie;
+//    }
+//
+//    private void addRefreshEntity(String username, String refresh, Long expiredMs) {
+//
+//        Date date = new Date(System.currentTimeMillis() + expiredMs);
+//
+//        RefreshEntity refreshEntity = new RefreshEntity();
+//        refreshEntity.setUsername(username);
+//        refreshEntity.setRefresh(refresh);
+//        refreshEntity.setExpiration(date.toString());
+//
+//        refreshRepository.save(refreshEntity);
+//    }
+//}
+
 package gaji.service.jwt.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import gaji.service.jwt.entity.RefreshEntity;
 import gaji.service.jwt.filter.JWTUtil;
 import gaji.service.jwt.rpository.RefreshRepository;
 import gaji.service.oauth2.dto.CustomOAuth2User;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Date;
-import java.util.Iterator;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
-
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
-
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
+    private final ObjectMapper objectMapper;
 
-    public CustomSuccessHandler(JWTUtil jwtUtil, RefreshRepository refreshRepository) {
+    public CustomSuccessHandler(JWTUtil jwtUtil, RefreshRepository refreshRepository, ObjectMapper objectMapper) {
         this.jwtUtil = jwtUtil;
         this.refreshRepository = refreshRepository;
+        this.objectMapper = objectMapper;
     }
 
-
     @Override
-    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException, IOException {
-        //OAuth2User
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
-
         String usernameId = customUserDetails.getName();
-        Collection<? extends GrantedAuthority> authorities = authentication.getAuthorities();
-        Iterator<? extends GrantedAuthority> iterator = authorities.iterator();
-        GrantedAuthority auth = iterator.next();
-        String role = auth.getAuthority();
+        String role = authentication.getAuthorities().stream()
+                .findFirst()
+                .map(GrantedAuthority::getAuthority)
+                .orElse("ROLE_USER");
 
-        //토큰 생성
         String access = jwtUtil.createJwt("access", usernameId, role, 600000L);
         String refresh = jwtUtil.createJwt("refresh", usernameId, role, 86400000L);
 
-        //DB에 저장되어 있는지 확인
-        Boolean isExist = refreshRepository.existsByUsername(usernameId);
-        if (!isExist) {
+        if (!refreshRepository.existsByUsername(usernameId)) {
             addRefreshEntity(usernameId, refresh, 86400000L);
         }
 
+        Map<String, String> tokens = new HashMap<>();
+        tokens.put("access_token", access);
+        tokens.put("refresh_token", refresh);
 
-        //응답 설정
-        response.setHeader("access", access);
-        response.addCookie(createCookie("refresh", refresh));
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
         response.setStatus(HttpStatus.OK.value());
-        response.sendRedirect("http://localhost:8080/my");
 
-    }
+        String tokensJson = objectMapper.writeValueAsString(tokens);
 
-    private Cookie createCookie(String key, String value) {
+        // 프론트엔드 URL에 토큰을 쿼리 파라미터로 추가
+        String redirectUrl = "http://localhost:8080/auth-success?tokens=" + tokensJson;
 
-        Cookie cookie = new Cookie(key, value);
-        cookie.setMaxAge(60*60*60);
-        cookie.setSecure(true);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true);
-
-        return cookie;
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
     }
 
     private void addRefreshEntity(String username, String refresh, Long expiredMs) {
-
         Date date = new Date(System.currentTimeMillis() + expiredMs);
-
         RefreshEntity refreshEntity = new RefreshEntity();
         refreshEntity.setUsername(username);
         refreshEntity.setRefresh(refresh);
         refreshEntity.setExpiration(date.toString());
-
         refreshRepository.save(refreshEntity);
     }
 }

--- a/src/main/java/gaji/service/jwt/service/ReissueService.java
+++ b/src/main/java/gaji/service/jwt/service/ReissueService.java
@@ -1,0 +1,111 @@
+package gaji.service.jwt.service;
+
+import gaji.service.jwt.entity.RefreshEntity;
+import gaji.service.jwt.filter.JWTUtil;
+import gaji.service.jwt.rpository.RefreshRepository;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Date;
+
+@Service
+@RequiredArgsConstructor
+public class ReissueService {
+
+    private final RefreshRepository refreshRepository;
+    private final JWTUtil jwtUtil;
+
+
+    public ResponseEntity<String> reissue(HttpServletRequest request, HttpServletResponse response){
+        //get refresh token
+        String refresh = null;
+        Cookie[] cookies = request.getCookies();
+        for (Cookie cookie : cookies) {
+
+            if (cookie.getName().equals("refresh")) {
+
+                refresh = cookie.getValue();
+            }
+        }
+
+        if (refresh == null) {
+
+            //response status code
+            return new ResponseEntity<>("refresh token null", HttpStatus.BAD_REQUEST);
+        }
+
+        //expired check
+        try {
+            jwtUtil.isExpired(refresh);
+        } catch (ExpiredJwtException e) {
+
+            //response status code
+            return new ResponseEntity<>("refresh token expired", HttpStatus.BAD_REQUEST);
+        }
+
+        // 토큰이 refresh인지 확인 (발급시 페이로드에 명시)
+        String category = jwtUtil.getCategory(refresh);
+
+        if (!category.equals("refresh")) {
+
+            //response status code
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        //DB에 저장되어 있는지 확인
+        Boolean isExist = refreshRepository.existsByRefresh(refresh);
+        if (!isExist) {
+            //response body
+            return new ResponseEntity<>("invalid refresh token", HttpStatus.BAD_REQUEST);
+        }
+
+        String username = jwtUtil.getUsername(refresh);
+        String role = jwtUtil.getRole(refresh);
+
+        //make new JWT
+        String newAccess = jwtUtil.createJwt("access", username, role, 600000L);
+        String newRefresh = jwtUtil.createJwt("refresh", username, role, 86400000L);
+
+        //Refresh 토큰 저장 DB에 기존의 Refresh 토큰 삭제 후 새 Refresh 토큰 저장
+        refreshRepository.deleteByRefresh(refresh);
+        addRefreshEntity(username, newRefresh, 86400000L);
+
+        //response
+        response.setHeader("access", newAccess);
+        response.addCookie(createCookie("refresh", newRefresh));
+
+
+        return null;
+    }
+
+
+    private void addRefreshEntity(String username, String refresh, Long expiredMs) {
+
+        Date date = new Date(System.currentTimeMillis() + expiredMs);
+
+        RefreshEntity refreshEntity = new RefreshEntity();
+        refreshEntity.setUsername(username);
+        refreshEntity.setRefresh(refresh);
+        refreshEntity.setExpiration(date.toString());
+
+        refreshRepository.save(refreshEntity);
+    }
+
+
+    private Cookie createCookie(String key, String value) {
+
+        Cookie cookie = new Cookie(key, value);
+        cookie.setMaxAge(24*60*60);
+        //cookie.setSecure(true);
+        //cookie.setPath("/");
+        cookie.setHttpOnly(true);
+
+        return cookie;
+    }
+}

--- a/src/main/java/gaji/service/jwt/service/TokenProviderService.java
+++ b/src/main/java/gaji/service/jwt/service/TokenProviderService.java
@@ -1,0 +1,27 @@
+package gaji.service.jwt.service;
+
+import gaji.service.domain.user.repository.UserRepository;
+import gaji.service.jwt.filter.JWTUtil;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TokenProviderService {
+    private final JWTUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    public TokenProviderService(JWTUtil jwtUtil, UserRepository userRepository) {
+        this.jwtUtil = jwtUtil;
+        this.userRepository = userRepository;
+    }
+
+    public Long getUserIdFromToken(String authorizationHeader) {
+        // "Bearer " 제거
+        String token = authorizationHeader.replace("Bearer ", "");
+
+        // 토큰에서 username 추출
+        String username = jwtUtil.getUsername(token);
+
+        // username으로 사용자 ID 조회
+        return userRepository.findByUsernameId(username).getId();
+    }
+}

--- a/src/main/java/gaji/service/oauth2/controller/Test2Controller.java
+++ b/src/main/java/gaji/service/oauth2/controller/Test2Controller.java
@@ -1,0 +1,93 @@
+package gaji.service.oauth2.controller;
+
+import gaji.service.domain.enums.Role;
+import gaji.service.domain.enums.ServiceRole;
+import gaji.service.jwt.filter.JWTUtil;
+import gaji.service.jwt.service.CustomSuccessHandler;
+import gaji.service.jwt.service.TokenProviderService;
+import gaji.service.oauth2.dto.CustomOAuth2User;
+import gaji.service.oauth2.dto.OAuthUserDTO;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.io.IOException;
+import java.util.Collection;
+
+@RestController
+public class Test2Controller {
+
+    private final CustomSuccessHandler customSuccessHandler;
+    private final TokenProviderService tokenProviderService;
+
+    public Test2Controller(CustomSuccessHandler customSuccessHandler, TokenProviderService tokenProviderService, JWTUtil jwtUtil, TokenProviderService tokenProviderService1) {
+        this.customSuccessHandler = customSuccessHandler;
+        this.tokenProviderService = tokenProviderService1;
+    }
+
+    @GetMapping("/my")
+    public ResponseEntity<Long> getUser(@RequestHeader("Authorization") String authorizationHeader) {
+            Long userId = tokenProviderService.getUserIdFromToken(authorizationHeader);
+            return ResponseEntity.ok(userId);
+
+    }
+    @GetMapping("/auth-success")
+    public void testAuthSuccess(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+        OAuthUserDTO oAuthUserDTO = new OAuthUserDTO();
+        oAuthUserDTO.setUsernameId("testUser");
+        oAuthUserDTO.setRole(ServiceRole.ROLE_USER); // Role은 enum이라고 가정합니다.
+
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(oAuthUserDTO);
+        Authentication authentication = new TestAuthentication(customOAuth2User);
+
+        customSuccessHandler.onAuthenticationSuccess(request, response, authentication);
+    }
+
+    private static class TestAuthentication implements Authentication {
+        private final CustomOAuth2User customOAuth2User;
+
+        public TestAuthentication(CustomOAuth2User customOAuth2User) {
+            this.customOAuth2User = customOAuth2User;
+        }
+
+        @Override
+        public Collection<? extends GrantedAuthority> getAuthorities() {
+            return customOAuth2User.getAuthorities();
+        }
+
+        @Override
+        public Object getCredentials() {
+            return null;
+        }
+
+        @Override
+        public Object getDetails() {
+            return null;
+        }
+
+        @Override
+        public Object getPrincipal() {
+            return customOAuth2User;
+        }
+
+        @Override
+        public boolean isAuthenticated() {
+            return true;
+        }
+
+        @Override
+        public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+        }
+
+        @Override
+        public String getName() {
+            return customOAuth2User.getName();
+        }
+    }
+}

--- a/src/main/java/gaji/service/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/gaji/service/oauth2/dto/CustomOAuth2User.java
@@ -1,0 +1,52 @@
+package gaji.service.oauth2.dto;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Map;
+
+public class CustomOAuth2User implements OAuth2User {
+
+    private final OAuthUserDTO oAuthUserDTO;
+
+    public CustomOAuth2User(OAuthUserDTO oAuthUserDTO) {
+
+        this.oAuthUserDTO = oAuthUserDTO;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        Collection<GrantedAuthority> collection = new ArrayList<>();
+
+        collection.add(new GrantedAuthority() {
+
+            @Override
+            public String getAuthority() {
+                return oAuthUserDTO.getRole().name();
+            }
+        });
+
+        return collection;
+    }
+
+    @Override
+    public String getName() {
+
+        return oAuthUserDTO.getUsernameId();
+    }
+
+//    public String getUsernameId() {
+//
+//        return oAuthUserDTO.getUsernameId();
+//    }
+
+}

--- a/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
@@ -1,0 +1,17 @@
+package gaji.service.oauth2.dto;
+
+import gaji.service.domain.enums.Role;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class OAuthUserDTO {
+
+    private Role role;
+    private String name;
+    // 서버에서 발급받는 아이디
+    private String usernameId;
+
+
+}

--- a/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
@@ -1,5 +1,6 @@
 package gaji.service.oauth2.dto;
 
+import gaji.service.domain.enums.Role;
 import gaji.service.domain.enums.ServiceRole;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
@@ -1,6 +1,6 @@
 package gaji.service.oauth2.dto;
 
-import gaji.service.domain.enums.Role;
+import gaji.service.domain.enums.ServiceRole;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Setter
 public class OAuthUserDTO {
 
-    private Role role;
+    private ServiceRole role;
     private String name;
     // 서버에서 발급받는 아이디
     private String usernameId;

--- a/src/main/java/gaji/service/oauth2/dto/TransferUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/TransferUserDTO.java
@@ -1,0 +1,25 @@
+package gaji.service.oauth2.dto;
+
+import gaji.service.domain.enums.Gender;
+import gaji.service.domain.enums.Role;
+import gaji.service.domain.enums.SocialType;
+import gaji.service.domain.enums.UserActive;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class TransferUserDTO {
+
+    private Role role;
+    private String name;
+    private Gender gender;
+    // 서버에서 발급받는 아이디
+    private String usernameId;
+    private String email;
+    private LocalDate birthday;
+    private SocialType socialType;
+    private UserActive userActive;
+}

--- a/src/main/java/gaji/service/oauth2/dto/TransferUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/TransferUserDTO.java
@@ -1,9 +1,6 @@
 package gaji.service.oauth2.dto;
 
-import gaji.service.domain.enums.Gender;
-import gaji.service.domain.enums.Role;
-import gaji.service.domain.enums.SocialType;
-import gaji.service.domain.enums.UserActive;
+import gaji.service.domain.enums.*;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -13,7 +10,7 @@ import java.time.LocalDate;
 @Setter
 public class TransferUserDTO {
 
-    private Role role;
+    private ServiceRole role;
     private String name;
     private Gender gender;
     // 서버에서 발급받는 아이디

--- a/src/main/java/gaji/service/oauth2/response/GoogleResponse.java
+++ b/src/main/java/gaji/service/oauth2/response/GoogleResponse.java
@@ -1,0 +1,57 @@
+package gaji.service.oauth2.response;
+
+import java.util.Map;
+
+public class GoogleResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    public GoogleResponse(Map<String, Object> attribute) {
+
+        this.attribute = attribute;
+    }
+
+    @Override
+    public String getProvider() {
+
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("sub").toString();
+    }
+
+    @Override
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+
+    @Override
+    public String getGender() {
+        return null;
+    }
+
+    @Override
+    public String getBirthday() {
+        return null;
+    }
+
+    @Override
+    public String getRole() {
+        return attribute.get("role").toString();
+    }
+
+    @Override
+    public String getBirthyear() {
+        return null;
+    }
+}

--- a/src/main/java/gaji/service/oauth2/response/NaverResponse.java
+++ b/src/main/java/gaji/service/oauth2/response/NaverResponse.java
@@ -1,0 +1,60 @@
+package gaji.service.oauth2.response;
+
+import java.util.Map;
+
+public class NaverResponse implements OAuth2Response{
+
+    private final Map<String, Object> attribute;
+
+    public NaverResponse(Map<String, Object> attribute) {
+
+        this.attribute = (Map<String, Object>) attribute.get("response");
+    }
+
+    @Override
+    public String getProvider() {
+
+        return "naver";
+    }
+
+    @Override
+    public String getProviderId() {
+
+        return attribute.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+
+        return attribute.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+
+        return attribute.get("name").toString();
+    }
+
+
+
+    @Override
+    public String getGender() {
+        return attribute.get("gender").toString();
+
+    }
+
+    @Override
+    public String getBirthday() {
+        return attribute.get("birthday").toString();
+    }
+
+    @Override
+    public String getBirthyear() {
+        return attribute.get("birthyear").toString();
+    }
+
+    @Override
+    public String getRole() {
+        return attribute.get("role").toString();
+    }
+}

--- a/src/main/java/gaji/service/oauth2/response/OAuth2Response.java
+++ b/src/main/java/gaji/service/oauth2/response/OAuth2Response.java
@@ -1,0 +1,25 @@
+package gaji.service.oauth2.response;
+
+public interface OAuth2Response {
+
+    //제공자 (Ex. naver, google, ...)
+    String getProvider();
+
+    //제공자에서 발급해주는 아이디(번호)
+    String getProviderId();
+
+    //이메일
+    String getEmail();
+
+    //사용자 실명 (설정한 이름)
+    String getName();
+
+
+    String getRole();
+
+    String getBirthday();
+
+    String getGender();
+
+    String getBirthyear();
+}

--- a/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
@@ -75,18 +75,19 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 userRepository.save(user);
             }
             else if (registrationId.equals("google")) {
-
                 TransferUserDTO transferUserDTO =new TransferUserDTO();
+
                 transferUserDTO.setUsernameId(usernameId);
                 transferUserDTO.setEmail(oAuth2Response.getEmail());
                 transferUserDTO.setName(oAuth2Response.getName());
-//                transferUserDTO.setGender(toEnumGender(oAuth2Response.getGender()));
+                transferUserDTO.setGender(toEnumGender(oAuth2Response.getGender()));
 //                transferUserDTO.setBirthday(formatDate(oAuth2Response.getBirthyear(), oAuth2Response.getBirthday()));
                 transferUserDTO.setUserActive(UserActive.ACTIVE);
                 transferUserDTO.setSocialType(setSocialType(registrationId));
                 transferUserDTO.setRole(Role.MEMBER);
 
                 User user = User.createUser(transferUserDTO); // 정적 팩토리 메서드 사용
+                System.out.println(user.getGender());
                 userRepository.save(user);
             }
 
@@ -102,19 +103,12 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             OAuthUserDTO oAuthuserDTO = new OAuthUserDTO();
             oAuthuserDTO.setUsernameId(usernameId);
             oAuthuserDTO.setRole(Role.MEMBER);
+
             return new CustomOAuth2User(oAuthuserDTO);
         }
     }
 
-    public Gender toEnumGender(String gender){
-        if (gender.equals("W")){
-            return Gender.FEMALE;
-        } else if (gender.equals("M")) {
-            return Gender.MALE;
-        }else {
-            return null;
-        }
-    }
+
     public LocalDate formatDate(String birthyear, String birthday){
         if(birthday == null){
             return null;
@@ -136,6 +130,21 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
     }
 
+
+    public Gender toEnumGender(String gender) {
+        if (gender == null) {
+            return Gender.UNKNOWN;
+        }
+        switch (gender.toUpperCase()) {
+            case "W":
+            case "F":
+                return Gender.FEMALE;
+            case "M":
+                return Gender.MALE;
+            default:
+                return Gender.UNKNOWN;
+        }
+    }
     public SocialType setSocialType(String social){
         if(social.equals("naver")){
             return SocialType.NAVER;

--- a/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
@@ -1,10 +1,7 @@
 package gaji.service.oauth2.service;
 
 import gaji.service.domain.User;
-import gaji.service.domain.enums.Gender;
-import gaji.service.domain.enums.Role;
-import gaji.service.domain.enums.SocialType;
-import gaji.service.domain.enums.UserActive;
+import gaji.service.domain.enums.*;
 import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.oauth2.dto.CustomOAuth2User;
 import gaji.service.oauth2.dto.OAuthUserDTO;
@@ -57,7 +54,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             OAuthUserDTO oAuthuserDTO = new OAuthUserDTO();
             oAuthuserDTO.setUsernameId(usernameId);
-            oAuthuserDTO.setRole(Role.MEMBER);
+            oAuthuserDTO.setRole(ServiceRole.ROLE_USER);
 
             if (registrationId.equals("naver")) {
 
@@ -69,7 +66,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                 transferUserDTO.setBirthday(formatDate(oAuth2Response.getBirthyear(), oAuth2Response.getBirthday()));
                 transferUserDTO.setUserActive(UserActive.ACTIVE);
                 transferUserDTO.setSocialType(setSocialType(registrationId));
-                transferUserDTO.setRole(Role.MEMBER);
+                transferUserDTO.setRole(ServiceRole.ROLE_USER);
 
                 User user = User.createUser(transferUserDTO); // 정적 팩토리 메서드 사용
                 userRepository.save(user);
@@ -84,7 +81,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 //                transferUserDTO.setBirthday(formatDate(oAuth2Response.getBirthyear(), oAuth2Response.getBirthday()));
                 transferUserDTO.setUserActive(UserActive.ACTIVE);
                 transferUserDTO.setSocialType(setSocialType(registrationId));
-                transferUserDTO.setRole(Role.MEMBER);
+                transferUserDTO.setRole(ServiceRole.ROLE_USER);
 
                 User user = User.createUser(transferUserDTO); // 정적 팩토리 메서드 사용
                 System.out.println(user.getGender());
@@ -102,7 +99,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
             OAuthUserDTO oAuthuserDTO = new OAuthUserDTO();
             oAuthuserDTO.setUsernameId(usernameId);
-            oAuthuserDTO.setRole(Role.MEMBER);
+            oAuthuserDTO.setRole(ServiceRole.ROLE_USER);
 
             return new CustomOAuth2User(oAuthuserDTO);
         }

--- a/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,150 @@
+package gaji.service.oauth2.service;
+
+import gaji.service.domain.User;
+import gaji.service.domain.enums.Gender;
+import gaji.service.domain.enums.Role;
+import gaji.service.domain.enums.SocialType;
+import gaji.service.domain.enums.UserActive;
+import gaji.service.domain.user.repository.UserRepository;
+import gaji.service.oauth2.dto.CustomOAuth2User;
+import gaji.service.oauth2.dto.OAuthUserDTO;
+import gaji.service.oauth2.dto.TransferUserDTO;
+import gaji.service.oauth2.response.GoogleResponse;
+import gaji.service.oauth2.response.NaverResponse;
+import gaji.service.oauth2.response.OAuth2Response;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2Response oAuth2Response = null;
+        if (registrationId.equals("naver")) {
+
+            oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+        }
+        else if (registrationId.equals("google")) {
+
+            oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+        }
+        else {
+
+            return null;
+        }
+
+        //리소스 서버에서 발급 받은 정보로 사용자를 특정할 아이디값을 만듬
+        String usernameId = oAuth2Response.getProvider()+" "+oAuth2Response.getProviderId();
+        User existData = userRepository.findByUsernameId(usernameId);
+
+        if (existData == null) {
+
+            OAuthUserDTO oAuthuserDTO = new OAuthUserDTO();
+            oAuthuserDTO.setUsernameId(usernameId);
+            oAuthuserDTO.setRole(Role.MEMBER);
+
+            if (registrationId.equals("naver")) {
+
+                TransferUserDTO transferUserDTO =new TransferUserDTO();
+                transferUserDTO.setUsernameId(usernameId);
+                transferUserDTO.setEmail(oAuth2Response.getEmail());
+                transferUserDTO.setName(oAuth2Response.getName());
+                transferUserDTO.setGender(toEnumGender(oAuth2Response.getGender()));
+                transferUserDTO.setBirthday(formatDate(oAuth2Response.getBirthyear(), oAuth2Response.getBirthday()));
+                transferUserDTO.setUserActive(UserActive.ACTIVE);
+                transferUserDTO.setSocialType(setSocialType(registrationId));
+                transferUserDTO.setRole(Role.MEMBER);
+
+                User user = User.createUser(transferUserDTO); // 정적 팩토리 메서드 사용
+                userRepository.save(user);
+            }
+            else if (registrationId.equals("google")) {
+
+                TransferUserDTO transferUserDTO =new TransferUserDTO();
+                transferUserDTO.setUsernameId(usernameId);
+                transferUserDTO.setEmail(oAuth2Response.getEmail());
+                transferUserDTO.setName(oAuth2Response.getName());
+//                transferUserDTO.setGender(toEnumGender(oAuth2Response.getGender()));
+//                transferUserDTO.setBirthday(formatDate(oAuth2Response.getBirthyear(), oAuth2Response.getBirthday()));
+                transferUserDTO.setUserActive(UserActive.ACTIVE);
+                transferUserDTO.setSocialType(setSocialType(registrationId));
+                transferUserDTO.setRole(Role.MEMBER);
+
+                User user = User.createUser(transferUserDTO); // 정적 팩토리 메서드 사용
+                userRepository.save(user);
+            }
+
+            return new CustomOAuth2User(oAuthuserDTO);
+
+        }else{
+
+            existData.setEmail(oAuth2Response.getEmail());
+            existData.setName(oAuth2Response.getName());
+
+            userRepository.save(existData);
+
+            OAuthUserDTO oAuthuserDTO = new OAuthUserDTO();
+            oAuthuserDTO.setUsernameId(usernameId);
+            oAuthuserDTO.setRole(Role.MEMBER);
+            return new CustomOAuth2User(oAuthuserDTO);
+        }
+    }
+
+    public Gender toEnumGender(String gender){
+        if (gender.equals("W")){
+            return Gender.FEMALE;
+        } else if (gender.equals("M")) {
+            return Gender.MALE;
+        }else {
+            return null;
+        }
+    }
+    public LocalDate formatDate(String birthyear, String birthday){
+        if(birthday == null){
+            return null;
+        }else{
+            try {
+                // birthday (MM-dd 형식)와 birthyear를 결합
+                String fullDateString = birthyear + "-" + birthday;
+
+                // 결합된 문자열을 파싱할 DateTimeFormatter 생성
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+                // 문자열을 LocalDate로 파싱
+                return LocalDate.parse(fullDateString, formatter);
+            } catch (DateTimeParseException e) {
+                System.out.println("Error parsing date: " + e.getMessage());
+                return null;
+            }
+        }
+
+    }
+
+    public SocialType setSocialType(String social){
+        if(social.equals("naver")){
+            return SocialType.NAVER;
+        }else{
+            return SocialType.GOOGLE;
+        }
+    }
+
+
+
+
+}


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#27-OAuth2/GAJI-60 -> develop

## 변경 사항
- 회원자체에 대한 권한, 스터디룸에 대한 권한을 분리했습니다.
- user 테이블엔 ServiceRole 사용 / StudyMate 테이블엔 Role 사용
 
## 이슈
- 헤더에 access와 refresh 토큰이 클라이언트에 전달이 안돼서 body에 담았습니다. 
- 소셜로그인을 하면 body에 access 와 refresh 토큰이 담겨져 갑니다.
- request Header에서 Authorization으로 access 토큰을 받아 user의 Id를  구하는 기능을 구현했습니다. 

## 테스트 결과
### 1. 로그인 url로 접속, 접속하면 로그인 화면으로 이동
네이버 : http://localhost:8080/oauth2/authorization/naver
구글 : http://localhost:8080/oauth2/authorization/google

![image](https://github.com/user-attachments/assets/3c3f3a4d-4f40-4f1e-965c-80386fd02280)


### 2. 로그인 완료 후 redirect된 url에서 access 토큰 복사
![image](https://github.com/user-attachments/assets/92179244-0fd1-4a22-b7f2-977e18149673)


### 3. 테스트를 위해서 Authorization에 access 토큰을 붙여넣는다. 그 후 send 를 누른다
![image](https://github.com/user-attachments/assets/6da12c43-809a-444b-80cc-e8a24204047b)

### 4. 추출된 user의 id를 테이블과 비교해본다.
![image](https://github.com/user-attachments/assets/1a19ba60-01ad-4ae6-9da0-62cbcbcfda02)
![image](https://github.com/user-attachments/assets/04e1405e-382a-4dc0-88e5-5f43f94ad4bc)


### 중요✨✨✨✨✨✨✨
이 게시글이 머지된 후 TokenProviderService 를 선언하여 Long userId = tokenProviderService.getUserIdFromToken(authorizationHeader); 형태로 userId를 구해주시면 됩니다.
![image](https://github.com/user-attachments/assets/34f5dbed-fcce-4ab4-a34f-da8ff6ca584c)



