### PR TITLE
✨ [feature] #59 - 유저 Soft Delete 및 닉네임 변경 API 구현

### DIFF
--- a/src/main/java/gaji/service/ServiceApplication.java
+++ b/src/main/java/gaji/service/ServiceApplication.java
@@ -5,10 +5,12 @@ import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 import java.util.TimeZone;
 
 @EnableJpaAuditing
+@EnableScheduling
 @SpringBootApplication
 public class ServiceApplication {
 

--- a/src/main/java/gaji/service/config/SecurityConfig.java
+++ b/src/main/java/gaji/service/config/SecurityConfig.java
@@ -34,7 +34,8 @@ public class SecurityConfig {
 
     private static final String[] AUTH_WHITELIST = {
             "/oauth2/**", "/swagger-ui/**", "/api-docs", "/swagger-ui-custom.html",
-            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/reissue", "/", "/my"
+            "/v3/api-docs/**", "/api-docs/**", "/swagger-ui.html", "/reissue", "/", "/my",
+            "/api/**"
     };
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {

--- a/src/main/java/gaji/service/config/SwaggerConfig.java
+++ b/src/main/java/gaji/service/config/SwaggerConfig.java
@@ -3,6 +3,8 @@ package gaji.service.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -11,15 +13,28 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
+
+        SecurityScheme apiKey = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization")
+                .scheme("Bearer")
+                .bearerFormat("JWT");
+
+        SecurityRequirement securityRequirement = new SecurityRequirement()
+                .addList("Bearer Token");
+
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components().addSecuritySchemes("Bearer Token", apiKey))
+                .addSecurityItem(securityRequirement)
                 .info(apiInfo());
     }
 
     private Info apiInfo() {
         return new Info()
-                .title("Spring Boot REST API Specifications")
-                .description("Specification")
+                .title("GAJI REST API Specifications")
+                .description("GAJI API 명세서입니다.")
                 .version("1.0.0");
     }
+
 }

--- a/src/main/java/gaji/service/domain/enums/UserActive.java
+++ b/src/main/java/gaji/service/domain/enums/UserActive.java
@@ -1,5 +1,5 @@
 package gaji.service.domain.enums;
 
 public enum UserActive {
-    ACTIVE, IN_ACTiVE
+    ACTIVE, IN_ACTIVE
 }

--- a/src/main/java/gaji/service/domain/user/code/UserErrorStatus.java
+++ b/src/main/java/gaji/service/domain/user/code/UserErrorStatus.java
@@ -11,7 +11,10 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorStatus implements BaseErrorCodeInterface {
 
     _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_4001", "존재하지 않는 회원입니다."),
+
+    //nickname 관련 Error
     _NICKNAME_IS_SAME_(HttpStatus.BAD_REQUEST, "USER_4002", "전과 동일한 닉네임으로 수정할 수 없습니다."),
+    _USER_IS_NOT_SAME_(HttpStatus.BAD_REQUEST, "USER_4003", "다른 회원의 닉네임을 수정할 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/gaji/service/domain/user/code/UserErrorStatus.java
+++ b/src/main/java/gaji/service/domain/user/code/UserErrorStatus.java
@@ -6,14 +6,13 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
-
 @Getter
 @AllArgsConstructor
 public enum UserErrorStatus implements BaseErrorCodeInterface {
-    // 스터디룸 게시판
-    _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_4001", "존재하지 않는 회원입니다.");
 
-
+    _USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER_4001", "존재하지 않는 회원입니다."),
+    _NICKNAME_IS_SAME_(HttpStatus.BAD_REQUEST, "USER_4002", "전과 동일한 닉네임으로 수정할 수 없습니다."),
+    ;
 
     private final HttpStatus httpStatus;
     private final boolean isSuccess = false;
@@ -22,7 +21,7 @@ public enum UserErrorStatus implements BaseErrorCodeInterface {
 
     @Override
     public BaseCodeDto getErrorCode() {
-        return BaseCodeDto.builder()
+        return gaji.service.global.exception.code.BaseCodeDto.builder()
                 .httpStatus(httpStatus)
                 .isSuccess(isSuccess)
                 .code(code)

--- a/src/main/java/gaji/service/domain/user/converter/UserConverter.java
+++ b/src/main/java/gaji/service/domain/user/converter/UserConverter.java
@@ -1,4 +1,22 @@
 package gaji.service.domain.user.converter;
 
+import gaji.service.domain.enums.UserActive;
+import gaji.service.domain.user.entity.User;
+import gaji.service.domain.user.web.dto.UserResponseDTO;
+
 public class UserConverter {
+    public static UserResponseDTO.CancleResultDTO toCancleResultDTO(User user) {
+        return UserResponseDTO.CancleResultDTO.builder()
+                .userId(user.getId())
+                .userActive(user.getStatus())
+                .build();
+    }
+
+    public static UserResponseDTO.UpdateNicknameResultDTO toUpdateNicknameResultDTO(User user) {
+        return UserResponseDTO.UpdateNicknameResultDTO.builder()
+                .userId(user.getId())
+                .nickname(user.getNickname())
+                .build();
+    }
+
 }

--- a/src/main/java/gaji/service/domain/user/entity/User.java
+++ b/src/main/java/gaji/service/domain/user/entity/User.java
@@ -192,5 +192,13 @@ public class User extends BaseEntity {
         this.usernameId = usernameId;
     }
 
+    public void updateStatus(UserActive status) {
+        this.status=status;
+        this.inactiveTime=LocalDateTime.now();
+    }
+
+    public void updateNickname(String nickname) {
+        this.nickname = nickname;
+    }
 
 }

--- a/src/main/java/gaji/service/domain/user/enums/UserDeletePeriod.java
+++ b/src/main/java/gaji/service/domain/user/enums/UserDeletePeriod.java
@@ -1,0 +1,17 @@
+package gaji.service.domain.user.enums;
+
+public enum UserDeletePeriod {
+    ONE_DAY(1),
+    ONE_WEEK(7),
+    ONE_MONTH(30);
+
+    private final int days;
+
+    UserDeletePeriod(int days) {
+        this.days = days;
+    }
+
+    public int getDays() {
+        return days;
+    }
+}

--- a/src/main/java/gaji/service/domain/user/repository/UserRepository.java
+++ b/src/main/java/gaji/service/domain/user/repository/UserRepository.java
@@ -3,9 +3,11 @@ package gaji.service.domain.user.repository;
 import gaji.service.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findById(Long id);
     User findByUsernameId(String username);
+    void deleteAllByInactiveTimeBefore(LocalDateTime time);
 }

--- a/src/main/java/gaji/service/domain/user/scheduler/UserScheduler.java
+++ b/src/main/java/gaji/service/domain/user/scheduler/UserScheduler.java
@@ -1,0 +1,18 @@
+package gaji.service.domain.user.scheduler;
+
+import gaji.service.domain.user.service.UserCommandService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UserScheduler {
+
+    private final UserCommandService userCommandService;
+
+    @Scheduled(cron = "0 0 0 * * ?")
+    public void removeDeletedUsers() {
+        userCommandService.hardDeleteInactiveUsers();
+    }
+}

--- a/src/main/java/gaji/service/domain/user/service/UserCommandService.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandService.java
@@ -5,6 +5,6 @@ import gaji.service.domain.user.web.dto.UserRequestDTO;
 
 public interface UserCommandService {
     public User cancleUser(Long userId);
-    public User updateUserNickname(Long userId, UserRequestDTO.UpdateNicknameDTO request);
+    public User updateUserNickname(Long userIdFromToken, Long userIdFromPathVariable, UserRequestDTO.UpdateNicknameDTO request);
     public void hardDeleteInactiveUsers();
 }

--- a/src/main/java/gaji/service/domain/user/service/UserCommandService.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandService.java
@@ -1,4 +1,10 @@
 package gaji.service.domain.user.service;
 
+import gaji.service.domain.user.entity.User;
+import gaji.service.domain.user.web.dto.UserRequestDTO;
+
 public interface UserCommandService {
+    public User cancleUser(Long userId);
+    public User updateUserNickname(Long userId, UserRequestDTO.UpdateNicknameDTO request);
+    public void hardDeleteInactiveUsers();
 }

--- a/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
@@ -1,7 +1,63 @@
 package gaji.service.domain.user.service;
 
+import gaji.service.domain.enums.UserActive;
+import gaji.service.domain.user.code.UserErrorStatus;
+import gaji.service.domain.user.entity.User;
+import gaji.service.domain.user.enums.UserDeletePeriod;
+import gaji.service.domain.user.repository.UserRepository;
+import gaji.service.domain.user.web.dto.UserRequestDTO;
+import gaji.service.global.exception.RestApiException;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Service
-public class UserCommandServiceImpl implements UserCommandService {
+@RequiredArgsConstructor
+public class UserCommandServiceImpl implements UserCommandService{
+
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public User cancleUser(Long userId) {
+        User user = updateUserStatus(userId, UserActive.IN_ACTIVE);
+
+        return user;
+    }
+
+    public User updateUserStatus(Long userId, UserActive status) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new RestApiException(UserErrorStatus._USER_NOT_FOUND));
+
+        user.updateStatus(status);
+
+        return user;
+    }
+
+    @Override
+    @Transactional
+    public User updateUserNickname(Long userId, UserRequestDTO.UpdateNicknameDTO request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new RestApiException(UserErrorStatus._USER_NOT_FOUND));
+
+        String newNickname = request.getNickname();
+
+        if (user.getNickname().equals(newNickname)) {
+            throw new RestApiException(UserErrorStatus._NICKNAME_IS_SAME_);
+        }
+        user.updateNickname(newNickname);
+
+        return user;
+    }
+
+    @Override
+    @Transactional
+    public void hardDeleteInactiveUsers() {
+        LocalDateTime cutoffDate = LocalDateTime.now()
+                .minusDays(UserDeletePeriod.ONE_MONTH.getDays());
+        userRepository.deleteAllByInactiveTimeBefore(cutoffDate);
+    }
 }

--- a/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
@@ -46,7 +46,7 @@ public class UserCommandServiceImpl implements UserCommandService{
 
         String newNickname = request.getNickname();
 
-        if (user.getNickname().equals(newNickname)) {
+        if (user.getNickname()!=null && user.getNickname().equals(newNickname)) {
             throw new RestApiException(UserErrorStatus._NICKNAME_IS_SAME_);
         }
 

--- a/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
@@ -12,13 +12,13 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UserCommandServiceImpl implements UserCommandService{
 
     private final UserRepository userRepository;
+    private final UserQueryService userQueryService;
 
     @Override
     @Transactional
@@ -29,9 +29,7 @@ public class UserCommandServiceImpl implements UserCommandService{
     }
 
     public User updateUserStatus(Long userId, UserActive status) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(()-> new RestApiException(UserErrorStatus._USER_NOT_FOUND));
-
+        User user = userQueryService.findUserById(userId);
         user.updateStatus(status);
 
         return user;
@@ -40,11 +38,9 @@ public class UserCommandServiceImpl implements UserCommandService{
     @Override
     @Transactional
     public User updateUserNickname(Long userIdFromToken, Long userIdFromPathVariable, UserRequestDTO.UpdateNicknameDTO request) {
-        User user = userRepository.findById(userIdFromToken)
-                .orElseThrow(()-> new RestApiException(UserErrorStatus._USER_NOT_FOUND));
+        User user = userQueryService.findUserById(userIdFromToken);
 
-        if(!user.equals(userRepository.findById(userIdFromPathVariable)
-                .orElseThrow(()-> new RestApiException(UserErrorStatus._USER_NOT_FOUND)))){
+        if(!user.equals(userQueryService.findUserById(userIdFromPathVariable))){
             throw new RestApiException(UserErrorStatus._USER_IS_NOT_SAME_);
         }
 
@@ -53,6 +49,7 @@ public class UserCommandServiceImpl implements UserCommandService{
         if (user.getNickname().equals(newNickname)) {
             throw new RestApiException(UserErrorStatus._NICKNAME_IS_SAME_);
         }
+
         user.updateNickname(newNickname);
 
         return user;

--- a/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
@@ -39,9 +39,14 @@ public class UserCommandServiceImpl implements UserCommandService{
 
     @Override
     @Transactional
-    public User updateUserNickname(Long userId, UserRequestDTO.UpdateNicknameDTO request) {
-        User user = userRepository.findById(userId)
+    public User updateUserNickname(Long userIdFromToken, Long userIdFromPathVariable, UserRequestDTO.UpdateNicknameDTO request) {
+        User user = userRepository.findById(userIdFromToken)
                 .orElseThrow(()-> new RestApiException(UserErrorStatus._USER_NOT_FOUND));
+
+        if(!user.equals(userRepository.findById(userIdFromPathVariable)
+                .orElseThrow(()-> new RestApiException(UserErrorStatus._USER_NOT_FOUND)))){
+            throw new RestApiException(UserErrorStatus._USER_IS_NOT_SAME_);
+        }
 
         String newNickname = request.getNickname();
 

--- a/src/main/java/gaji/service/domain/user/web/controller/UserRestController.java
+++ b/src/main/java/gaji/service/domain/user/web/controller/UserRestController.java
@@ -9,6 +9,7 @@ import gaji.service.domain.user.service.UserQueryService;
 import gaji.service.domain.user.web.dto.UserRequestDTO;
 import gaji.service.domain.user.web.dto.UserResponseDTO;
 import gaji.service.global.base.BaseResponse;
+import gaji.service.jwt.service.TokenProviderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -21,22 +22,23 @@ import java.util.List;
 public class UserRestController {
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
+    private final TokenProviderService tokenProviderService;
 
     @PutMapping("/")
-    public BaseResponse<UserResponseDTO.CancleResultDTO> cancle(Long userId/*하드 코딩용 추후 수정.*/) {
-        //Long myId = getUserIdFromToken(token);
+    public BaseResponse<UserResponseDTO.CancleResultDTO> cancle(@RequestHeader("Authorization") String authorizationHeader) {
 
+        Long userId = tokenProviderService.getUserIdFromToken(authorizationHeader);
         User user = userCommandService.cancleUser(userId);
         return BaseResponse.onSuccess(UserConverter.toCancleResultDTO(user));
     }
 
 
     @PutMapping("/nicknames")
-    public BaseResponse<UserResponseDTO.UpdateNicknameResultDTO> updateNickname(Long userId/*하드 코딩용 추후 수정.*/,
+    public BaseResponse<UserResponseDTO.UpdateNicknameResultDTO> updateNickname(@RequestHeader("Authorization") String authorizationHeader,
                                                                                 @RequestBody @Valid UserRequestDTO.UpdateNicknameDTO request
                                                                                 ) {
-        //Long myId = getUserIdFromToken(token);
 
+        Long userId = tokenProviderService.getUserIdFromToken(authorizationHeader);
         User user = userCommandService.updateUserNickname(userId, request);
         return BaseResponse.onSuccess(UserConverter.toUpdateNicknameResultDTO(user));
     }

--- a/src/main/java/gaji/service/domain/user/web/controller/UserRestController.java
+++ b/src/main/java/gaji/service/domain/user/web/controller/UserRestController.java
@@ -1,16 +1,19 @@
 package gaji.service.domain.user.web.controller;
 
+import gaji.service.domain.enums.PostTypeEnum;
+import gaji.service.domain.post.entity.Post;
 import gaji.service.domain.user.converter.UserConverter;
 import gaji.service.domain.user.entity.User;
 import gaji.service.domain.user.service.UserCommandService;
 import gaji.service.domain.user.service.UserQueryService;
+import gaji.service.domain.user.web.dto.UserRequestDTO;
 import gaji.service.domain.user.web.dto.UserResponseDTO;
 import gaji.service.global.base.BaseResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/api/users")
@@ -18,5 +21,24 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserRestController {
     private final UserCommandService userCommandService;
     private final UserQueryService userQueryService;
+
+    @PutMapping("/")
+    public BaseResponse<UserResponseDTO.CancleResultDTO> cancle(Long userId/*하드 코딩용 추후 수정.*/) {
+        //Long myId = getUserIdFromToken(token);
+
+        User user = userCommandService.cancleUser(userId);
+        return BaseResponse.onSuccess(UserConverter.toCancleResultDTO(user));
+    }
+
+
+    @PutMapping("/nicknames")
+    public BaseResponse<UserResponseDTO.UpdateNicknameResultDTO> updateNickname(Long userId/*하드 코딩용 추후 수정.*/,
+                                                                                @RequestBody @Valid UserRequestDTO.UpdateNicknameDTO request
+                                                                                ) {
+        //Long myId = getUserIdFromToken(token);
+
+        User user = userCommandService.updateUserNickname(userId, request);
+        return BaseResponse.onSuccess(UserConverter.toUpdateNicknameResultDTO(user));
+    }
 }
 

--- a/src/main/java/gaji/service/domain/user/web/controller/UserRestController.java
+++ b/src/main/java/gaji/service/domain/user/web/controller/UserRestController.java
@@ -2,6 +2,7 @@ package gaji.service.domain.user.web.controller;
 
 import gaji.service.domain.enums.PostTypeEnum;
 import gaji.service.domain.post.entity.Post;
+import gaji.service.domain.user.code.UserErrorStatus;
 import gaji.service.domain.user.converter.UserConverter;
 import gaji.service.domain.user.entity.User;
 import gaji.service.domain.user.service.UserCommandService;
@@ -9,6 +10,7 @@ import gaji.service.domain.user.service.UserQueryService;
 import gaji.service.domain.user.web.dto.UserRequestDTO;
 import gaji.service.domain.user.web.dto.UserResponseDTO;
 import gaji.service.global.base.BaseResponse;
+import gaji.service.global.exception.RestApiException;
 import gaji.service.jwt.service.TokenProviderService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -33,13 +35,14 @@ public class UserRestController {
     }
 
 
-    @PutMapping("/nicknames")
+    @PutMapping("/nicknames/{userId}")
     public BaseResponse<UserResponseDTO.UpdateNicknameResultDTO> updateNickname(@RequestHeader("Authorization") String authorizationHeader,
-                                                                                @RequestBody @Valid UserRequestDTO.UpdateNicknameDTO request
-                                                                                ) {
+                                                                                @PathVariable("userId") Long userIdFromPathVariable,
+                                                                                @RequestBody @Valid UserRequestDTO.UpdateNicknameDTO request) {
 
-        Long userId = tokenProviderService.getUserIdFromToken(authorizationHeader);
-        User user = userCommandService.updateUserNickname(userId, request);
+
+        Long userIdFromToken = tokenProviderService.getUserIdFromToken(authorizationHeader);
+        User user = userCommandService.updateUserNickname(userIdFromToken, userIdFromPathVariable, request);
         return BaseResponse.onSuccess(UserConverter.toUpdateNicknameResultDTO(user));
     }
 }

--- a/src/main/java/gaji/service/domain/user/web/dto/UserRequestDTO.java
+++ b/src/main/java/gaji/service/domain/user/web/dto/UserRequestDTO.java
@@ -1,0 +1,17 @@
+package gaji.service.domain.user.web.dto;
+
+import gaji.service.domain.enums.PostTypeEnum;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+public class UserRequestDTO {
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class UpdateNicknameDTO {
+        @NotBlank(message = "공백은 불가능합니다.") //추후 닉네임 제약으로 수정가능성 ex) 닉네임은 2~10글자
+        private String nickname;
+    }
+
+}

--- a/src/main/java/gaji/service/domain/user/web/dto/UserResponseDTO.java
+++ b/src/main/java/gaji/service/domain/user/web/dto/UserResponseDTO.java
@@ -1,13 +1,42 @@
 package gaji.service.domain.user.web.dto;
 
+import gaji.service.domain.enums.UserActive;
+import gaji.service.domain.post.entity.Post;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
+import java.util.List;
 
 public class UserResponseDTO {
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class CancleResultDTO {
+        Long userId;
+        UserActive userActive;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class GetPostsResultDTO {
+        Long userId;
+        List<Long> postIds;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UpdateNicknameResultDTO {
+        Long userId;
+        String nickname;
+    }
 }
 
 


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#59-user/GAJI-67,73 -> develop

## 변경 사항
닉네임 업데이트 API 구현(공백,같은 닉네임 불가)
ServiceApplication에 @EnableScheduling 추가

## 이슈
IN_ACTIVE 유저 삭제 주기를 00:00(자정) 으로 설정하였습니다.

## 테스트 결과
-닉네임 변경 성공시
![닉변](https://github.com/user-attachments/assets/c5536c6a-4f05-4db9-be50-efd46cd5dff6)

-닉네임 변경 실패시
![공백](https://github.com/user-attachments/assets/f5237e0f-7e9e-438f-a576-d051581cdbdb)
![동일닉](https://github.com/user-attachments/assets/8de990e4-04f2-425f-99ea-1075df5a0732)

-다른 사용자가 닉네임 변경을 시도할시
![다른 회원이 닉네임 수정 요청할 경우](https://github.com/user-attachments/assets/fb7a26a0-9d2b-4471-a4c5-8c1a73d62c4c)


-유저 삭제시
![SD](https://github.com/user-attachments/assets/53c795fa-9572-4696-92ef-686271d99a96)

