### PR TITLE
🔨[FIX] #80 - CustonSuccessHandlerAPI 수정

### DIFF
--- a/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
+++ b/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
@@ -6,9 +6,10 @@ import gaji.service.jwt.filter.JWTUtil;
 import gaji.service.jwt.rpository.RefreshRepository;
 import gaji.service.oauth2.dto.CustomOAuth2User;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -22,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Component
-@Slf4j
 public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
     private final JWTUtil jwtUtil;
     private final RefreshRepository refreshRepository;
@@ -43,34 +43,43 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
                 .map(GrantedAuthority::getAuthority)
                 .orElse("ROLE_USER");
 
-        String access = jwtUtil.createJwt("access", usernameId, role, 600000L);
-        String refresh = jwtUtil.createJwt("refresh", usernameId, role, 86400000L);
+        String accessToken = jwtUtil.createJwt("access", usernameId, role, 600000L);
+        String refreshToken = jwtUtil.createJwt("refresh", usernameId, role, 86400000L);
 
         if (!refreshRepository.existsByUsername(usernameId)) {
-            addRefreshEntity(usernameId, refresh, 86400000L);
+            addRefreshEntity(usernameId, refreshToken, 86400000L);
         }
 
-        Map<String, String> tokens = new HashMap<>();
-        tokens.put("access_token", access);
-        tokens.put("refresh_token", refresh);
+
+
+        // Refresh 토큰을 HttpOnly 쿠키로 설정
+        Cookie refreshTokenCookie = new Cookie("refresh_token", refreshToken);
+        refreshTokenCookie.setHttpOnly(true);
+        refreshTokenCookie.setSecure(true); // HTTPS에서만 사용
+        refreshTokenCookie.setPath("/");
+        refreshTokenCookie.setMaxAge(86400); // 24시간
+        response.addCookie(refreshTokenCookie);
+
+
+        // 1. 헤더로 보낼 경우
+//        response.setHeader("Authorization", "Bearer " + accessToken);
+
+
+
+        // 2. body에 담아서 보낼 경우 Access 토큰을 JSON 응답으로 전송
+        Map<String, String> tokenResponse = new HashMap<>();
+        tokenResponse.put("access_token", accessToken);
 
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(objectMapper.writeValueAsString(tokenResponse));
         response.setStatus(HttpStatus.OK.value());
+        //
 
-        // 생성된 토큰 로그 찍어주기
-        log.info("accessToken = {}", access);
-        log.info("refreshToken = {}", refresh);
-
-        String tokensJson = objectMapper.writeValueAsString(tokens);
-
-        // 프론트엔드 URL에 토큰을 쿼리 파라미터로 추가
-        String redirectUrl = "http://localhost:8080/auth-success?tokens=" + tokensJson;
-
-        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+        System.out.println("Access Token: " + accessToken);
+        System.out.println("Refresh Token: " + refreshToken);
     }
 
-    // TODO: 빌더 패턴으로 변경
     private void addRefreshEntity(String username, String refresh, Long expiredMs) {
         Date date = new Date(System.currentTimeMillis() + expiredMs);
         RefreshEntity refreshEntity = new RefreshEntity();


### PR DESCRIPTION
로그인이 성공적으로 진행되면 joson 형식으로 body에 담겨 전달된다. 이 때 refeshToken은 헤더에 담긴다.

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex)  feature/#80-CustomSuccessHandler-Fix/GAJI-115 -> develop

## 변경 사항
- access 토큰이 제대로 전달 되도록 코드를 수정
- 이슈를 수정하여 로그인 성공하면 json 형식으로 body에 access 토큰이 담겨서 전달이 되는 방식으로 수정

## 이슈
- 기존 코드는 소셜로그인 성공시 404 페이지와 함께 url에 access 토큰이 담겨서 전달됨


## 테스트 결과
### 로그인 성공시 쿠키 및 액세스 토큰 
<쿠키(refresh)>
![image](https://github.com/user-attachments/assets/591d5c96-ecdb-4391-b18d-bd54db44289a)

<access 토큰>
![image](https://github.com/user-attachments/assets/0b39ccfb-5d02-4584-a19f-6b37460cb7d0)



<ide에서 출력된 access 와 refresh 토큰과 같다.>
![image](https://github.com/user-attachments/assets/d201e7a2-a380-4880-a189-ced0dc5e1d22)


Access Token: eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6ImFjY2VzcyIsInVzZXJuYW1lIjoibmF2ZXIgQlFzM09WWWwyaUhyWEtaR0g0bE03V2hzbG0yRWVDUFhWbmJkTGd4Nnp5ayIsInJvbGUiOiJST0xFX1VTRVIiLCJpYXQiOjE3MjM1MzA3MTIsImV4cCI6MTcyMzUzMTMxMn0.8IeZdQhIhUJbVguqhBEaCpw8hY9rGc-wDg7doWxRQZ8

Refresh Token: eyJhbGciOiJIUzI1NiJ9.eyJjYXRlZ29yeSI6InJlZnJlc2giLCJ1c2VybmFtZSI6Im5hdmVyIEJRczNPVllsMmlIclhLWkdINGxNN1doc2xtMkVlQ1BYVm5iZExneDZ6eWsiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNzIzNTMwNzEyLCJleHAiOjE3MjM2MTcxMTJ9.-s0cssD9Zym8dwWZgPkqqchn3X04XQa7R_Uoq5VyqGY
