### PR TITLE
⚙[Setting] #104 - SecurityConfig, CorsMvcConfig 수정 

### DIFF
--- a/src/main/java/gaji/service/config/CorsMvcConfig.java
+++ b/src/main/java/gaji/service/config/CorsMvcConfig.java
@@ -1,4 +1,4 @@
-package gaji.service.jwt.config;
+package gaji.service.config;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
@@ -9,9 +9,12 @@ public class CorsMvcConfig implements WebMvcConfigurer {
 
     @Override
     public void addCorsMappings(CorsRegistry corsRegistry) {
-
         corsRegistry.addMapping("/**")
-                .exposedHeaders("Set-Cookie")
-                .allowedOrigins("http://localhost:3000");
+                .allowedOrigins("http://localhost:3000", "http://3.35.119.128")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedHeaders("*")
+                .exposedHeaders("Authorization", "Set-Cookie")
+                .allowCredentials(true)
+                .maxAge(3600);
     }
 }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#104-Security-CorsMvc-fix/GAJI-126 -> develop

## 변경 사항
- 허용된 오리진에 저희가 접근하려는 주소를 추가하여 해당 서버에서의 접근을 허용하였습니다.
- 명시적으로 허용된 HTTP 메소드를 지정하여 PUT, DELETE 등의 요청도 허용했습니다.
- 모든 헤더를 허용하고, 'Authorization'과 'Set-Cookie' 헤더를 노출시켜 클라이언트에서 이 헤더들에 접근할 수 있게 하였습니다.
- CORS 설정을 별도의 corsConfigurationSource 빈으로 분리하여 가독성과 유지보수성을 향상시켰습니다.

## 이슈
- 오직 "http://localhost:3000"만 허용되어 있어, 다른 도메인(ec2주소)에서의 접근이 차단되는 상태입니다.
- 허용된 HTTP 메소드가 명시적으로 지정되어 있지 않아, 일부 요청(특히 PUT, DELETE)이 차단되는 상태입니다.
- CorsMvcConfig와 SecurityConfig 양쪽에서 CORS 설정을 하고 있어 혼란을 주는 상태입니다.

## 테스트 결과

