### PR TITLE
✨ [feature] #116 - 스터디룸 게시글, 정보나눔 게시글, 트러블슈팅 게시글  상세 조회, 댓글 무한 스크롤  API 구현

### DIFF
--- a/src/main/java/gaji/service/domain/roomBoard/entity/RoomInfo/InfoPostComment.java
+++ b/src/main/java/gaji/service/domain/roomBoard/entity/RoomInfo/InfoPostComment.java
@@ -1,5 +1,6 @@
 package gaji.service.domain.roomBoard.entity.RoomInfo;
 
+import gaji.service.domain.common.entity.BaseEntity;
 import gaji.service.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class InfoPostComment {
+public class InfoPostComment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/gaji/service/domain/roomBoard/entity/RoomPost/PostComment.java
+++ b/src/main/java/gaji/service/domain/roomBoard/entity/RoomPost/PostComment.java
@@ -1,5 +1,6 @@
 package gaji.service.domain.roomBoard.entity.RoomPost;
 
+import gaji.service.domain.common.entity.BaseEntity;
 import gaji.service.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class PostComment {
+public class PostComment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/gaji/service/domain/roomBoard/entity/RoomTrouble/TroublePostComment.java
+++ b/src/main/java/gaji/service/domain/roomBoard/entity/RoomTrouble/TroublePostComment.java
@@ -1,5 +1,6 @@
 package gaji.service.domain.roomBoard.entity.RoomTrouble;
 
+import gaji.service.domain.common.entity.BaseEntity;
 import gaji.service.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
@@ -12,7 +13,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
 @AllArgsConstructor
-public class TroublePostComment {
+public class TroublePostComment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/InfoPostCommentRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/InfoPostCommentRepository.java
@@ -1,9 +1,20 @@
 package gaji.service.domain.roomBoard.repository.RoomInfo;
 
 import gaji.service.domain.roomBoard.entity.RoomInfo.InfoPostComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface InfoPostCommentRepository extends JpaRepository<InfoPostComment, Long> {
+
+    @Query("SELECT c FROM InfoPostComment c " +
+            "LEFT JOIN FETCH c.replies " +
+            "WHERE c.roomInfoPost.id = :postId " +
+            "AND c.parentComment IS NULL " +
+            "ORDER BY c.createdAt ASC, c.id ASC")
+    Page<InfoPostComment> findOldestComments(@Param("postId") Long postId, Pageable pageable);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/RoomInfoPostRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/RoomInfoPostRepository.java
@@ -1,7 +1,9 @@
 package gaji.service.domain.roomBoard.repository.RoomInfo;
 
+import gaji.service.domain.roomBoard.entity.RoomInfo.InfoPostComment;
 import gaji.service.domain.roomBoard.entity.RoomInfo.RoomInfoPost;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -21,4 +23,5 @@ public interface RoomInfoPostRepository extends JpaRepository<RoomInfoPost, Long
             @Param("boardId") Long boardId,
             @Param("lastPostId") Long lastPostId,
             Pageable pageable);
+
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomPost/PostCommentRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomPost/PostCommentRepository.java
@@ -1,9 +1,19 @@
 package gaji.service.domain.roomBoard.repository.RoomPost;
 
 import gaji.service.domain.roomBoard.entity.RoomPost.PostComment;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface PostCommentRepository extends JpaRepository<PostComment, Long> {
+    @Query("SELECT c FROM PostComment c " +
+            "LEFT JOIN FETCH c.replies " +
+            "WHERE c.roomPost.id = :postId " +
+            "AND c.parentComment IS NULL " +
+            "ORDER BY c.createdAt ASC, c.id ASC")
+    Page<PostComment> findOldestComments(@Param("postId") Long postId, Pageable pageable);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
@@ -1,9 +1,23 @@
 package gaji.service.domain.roomBoard.repository.RoomTrouble;
 
 import gaji.service.domain.roomBoard.entity.RoomTrouble.TroublePostComment;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface TroublePostCommentRepository extends JpaRepository<TroublePostComment, Long> {
+    List<TroublePostComment> findByRoomTroublePostIdAndIsReplyFalse(Long postId);
+
+    @Query("SELECT c FROM TroublePostComment c WHERE c.roomTroublePost.id = :postId AND c.id > :lastCommentId AND c.isReply = false ORDER BY c.id")
+    List<TroublePostComment> findMoreComments(@Param("postId") Long postId, @Param("lastCommentId") Long lastCommentId, Pageable pageable);
+
+    @Query("SELECT c FROM TroublePostComment c WHERE c.parentComment.id = :commentId AND c.id > :lastReplyId ORDER BY c.id")
+    List<TroublePostComment> findMoreReplies(@Param("commentId") Long commentId, @Param("lastReplyId") Long lastReplyId, Pageable pageable);
+
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
@@ -1,6 +1,7 @@
 package gaji.service.domain.roomBoard.repository.RoomTrouble;
 
 import gaji.service.domain.roomBoard.entity.RoomTrouble.TroublePostComment;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -12,12 +13,19 @@ import java.util.List;
 
 @Repository
 public interface TroublePostCommentRepository extends JpaRepository<TroublePostComment, Long> {
-    List<TroublePostComment> findByRoomTroublePostIdAndIsReplyFalse(Long postId);
+    @Query("SELECT c FROM TroublePostComment c " +
+            "LEFT JOIN FETCH c.replies " +
+            "WHERE c.roomTroublePost.id = :postId " +
+            "AND c.isReply = false " +
+            "AND (:lastCommentId IS NULL OR c.id > :lastCommentId) " +
+            "ORDER BY c.createdAt ASC, c.id ASC")
+    List<TroublePostComment> findCommentsWithReplies(@Param("postId") Long postId,
+                                                     @Param("lastCommentId") Long lastCommentId,
+                                                     Pageable pageable);
 
-    @Query("SELECT c FROM TroublePostComment c WHERE c.roomTroublePost.id = :postId AND c.id > :lastCommentId AND c.isReply = false ORDER BY c.id")
-    List<TroublePostComment> findMoreComments(@Param("postId") Long postId, @Param("lastCommentId") Long lastCommentId, Pageable pageable);
-
-    @Query("SELECT c FROM TroublePostComment c WHERE c.parentComment.id = :commentId AND c.id > :lastReplyId ORDER BY c.id")
-    List<TroublePostComment> findMoreReplies(@Param("commentId") Long commentId, @Param("lastReplyId") Long lastReplyId, Pageable pageable);
-
+    @Query("SELECT c FROM TroublePostComment c " +
+            "WHERE c.roomTroublePost.id = :postId " +
+            "AND c.isReply = false " +
+            "ORDER BY c.createdAt ASC, c.id ASC")
+    Page<TroublePostComment> findOldestComments(@Param("postId") Long postId, Pageable pageable);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomInfo/RoomInfoPostQueryService.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomInfo/RoomInfoPostQueryService.java
@@ -3,6 +3,8 @@ package gaji.service.domain.roomBoard.service.RoomInfo;
 import gaji.service.domain.roomBoard.entity.RoomInfo.InfoPostComment;
 import gaji.service.domain.roomBoard.entity.RoomInfo.RoomInfoPost;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -14,4 +16,8 @@ public interface RoomInfoPostQueryService {
     InfoPostComment findPostCommentById(Long troublePostId);
 
     List<RoomPostResponseDto.InfoPostSummaryDto> getNextPosts(Long boardId, Long lastPostId, int size);
+
+    RoomPostResponseDto.RoomInfoPostDetailDTO getPostDetail(Long postId, Long userId, int page, int size);
+
+    Page<RoomPostResponseDto.CommentWithRepliesDTO> getCommentsWithReplies(Long postId, Pageable pageable);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostQueryService.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostQueryService.java
@@ -3,6 +3,8 @@ package gaji.service.domain.roomBoard.service.RoomPost;
 import gaji.service.domain.roomBoard.entity.RoomPost.PostComment;
 import gaji.service.domain.roomBoard.entity.RoomPost.RoomPost;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -18,4 +20,8 @@ public interface RoomPostQueryService {
     PostComment findCommentByCommentId(Long commentId);
 
     PostComment findPostCommentById(Long troublePostId);
+
+    RoomPostResponseDto.RoomPostDetailDTO getPostDetail(Long postId, Long userId, int page, int size);
+
+    Page<RoomPostResponseDto.CommentWithRepliesDTO> getCommentsWithReplies(Long postId, Pageable pageable);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryService.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryService.java
@@ -13,4 +13,8 @@ public interface RoomTroublePostQueryService {
     List<RoomPostResponseDto.TroublePostSummaryDto> getNextTroublePosts(Long boardId, Long lastPostId, int size);
 
     RoomPostResponseDto.TroublePostDetailDTO getPostDetail(Long postId, Long userId);
+
+    List<RoomPostResponseDto.CommentDTO> getMoreComments(Long postId, Long lastCommentId, int size);
+
+    List<RoomPostResponseDto.CommentDTO> getMoreReplies(Long commentId, Long lastReplyId, int size);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryService.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryService.java
@@ -2,6 +2,8 @@ package gaji.service.domain.roomBoard.service.RoomTrouble;
 
 import gaji.service.domain.roomBoard.entity.RoomTrouble.TroublePostComment;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 
@@ -12,9 +14,7 @@ public interface RoomTroublePostQueryService {
 
     List<RoomPostResponseDto.TroublePostSummaryDto> getNextTroublePosts(Long boardId, Long lastPostId, int size);
 
-    RoomPostResponseDto.TroublePostDetailDTO getPostDetail(Long postId, Long userId);
+    RoomPostResponseDto.TroublePostDetailDTO getPostDetail(Long postId, Long userId, int page, int size);
 
-    List<RoomPostResponseDto.CommentDTO> getMoreComments(Long postId, Long lastCommentId, int size);
-
-    List<RoomPostResponseDto.CommentDTO> getMoreReplies(Long commentId, Long lastReplyId, int size);
+    Page<RoomPostResponseDto.CommentWithRepliesDTO> getCommentsWithReplies(Long postId, Pageable pageable);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryService.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryService.java
@@ -11,4 +11,6 @@ public interface RoomTroublePostQueryService {
     TroublePostComment findTroublePostCommentById(Long troublePostId);
 
     List<RoomPostResponseDto.TroublePostSummaryDto> getNextTroublePosts(Long boardId, Long lastPostId, int size);
+
+    RoomPostResponseDto.TroublePostDetailDTO getPostDetail(Long postId, Long userId);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
@@ -92,6 +92,7 @@ public class RoomTroublePostQueryServiceImpl implements RoomTroublePostQueryServ
         return dto;
     }
 
+    @Override
     public List<RoomPostResponseDto.CommentDTO> getMoreComments(Long postId, Long lastCommentId, int size) {
         List<TroublePostComment> comments = troublePostCommentRepository
                 .findMoreComments(postId, lastCommentId, PageRequest.of(0, size));
@@ -100,6 +101,7 @@ public class RoomTroublePostQueryServiceImpl implements RoomTroublePostQueryServ
                 .collect(Collectors.toList());
     }
 
+    @Override
     public List<RoomPostResponseDto.CommentDTO> getMoreReplies(Long commentId, Long lastReplyId, int size) {
         List<TroublePostComment> replies = troublePostCommentRepository
                 .findMoreReplies(commentId, lastReplyId, PageRequest.of(0, size));

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
@@ -1,10 +1,13 @@
 package gaji.service.domain.roomBoard.service.RoomTrouble;
 
 import gaji.service.domain.roomBoard.code.RoomPostErrorStatus;
+import gaji.service.domain.roomBoard.entity.RoomTrouble.RoomTroublePost;
 import gaji.service.domain.roomBoard.entity.RoomTrouble.TroublePostComment;
 import gaji.service.domain.roomBoard.repository.RoomTrouble.RoomTroublePostRepository;
 import gaji.service.domain.roomBoard.repository.RoomTrouble.TroublePostCommentRepository;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
+import gaji.service.domain.studyMate.entity.StudyMate;
+import gaji.service.domain.studyMate.service.StudyMateQueryService;
 import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -13,6 +16,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +24,8 @@ public class RoomTroublePostQueryServiceImpl implements RoomTroublePostQueryServ
 
     private final TroublePostCommentRepository troublePostCommentRepository;
     private final RoomTroublePostRepository roomTroublePostRepository;
+    private final StudyMateQueryService studyMateQueryService;
+
     @Override
     public TroublePostComment findCommentByCommentId(Long commentId){
         return troublePostCommentRepository.findById(commentId)
@@ -36,5 +42,69 @@ public class RoomTroublePostQueryServiceImpl implements RoomTroublePostQueryServ
     public List<RoomPostResponseDto.TroublePostSummaryDto> getNextTroublePosts(Long boardId, Long lastPostId, int size) {
         Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         return roomTroublePostRepository.findTroublePostSummariesForInfiniteScroll(boardId, lastPostId,pageable);
+    }
+
+
+
+    @Override
+    public RoomPostResponseDto.TroublePostDetailDTO getPostDetail(Long postId, Long userId) {
+        RoomTroublePost post = roomTroublePostRepository.findById(postId)
+                .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._POST_NOT_FOUND));
+
+        StudyMate studyMate = studyMateQueryService.findByUserIdAndRoomId(userId, post.getRoomBoard().getRoom().getId());
+
+        RoomPostResponseDto.TroublePostDetailDTO dto = new RoomPostResponseDto.TroublePostDetailDTO();
+        dto.setId(post.getId());
+        dto.setTitle(post.getTitle());
+        dto.setBody(post.getBody());
+        dto.setAuthorName(post.getStudyMate().getUser().getName());
+        dto.setCreatedAt(post.getCreatedAt());
+        dto.setViewCount(post.getViewCount());
+        dto.setLikeCount(post.getLikeCount());
+        dto.setBookmarkCount(post.getBookmarkCount());
+        dto.setLiked(post.getRoomTroublePostLikeList().stream()
+                .anyMatch(like -> like.getStudyMate().getId().equals(studyMate.getId())));
+        dto.setBookmarked(post.getRoomTroublePostBookmarkList().stream()
+                .anyMatch(bookmark -> bookmark.getStudyMate().getId().equals(studyMate.getId())));
+
+        List<RoomPostResponseDto.CommentDTO> comments = getCommentsWithReplies(post.getId());
+        dto.setComments(comments);
+
+        return dto;
+    }
+
+    private List<RoomPostResponseDto.CommentDTO> getCommentsWithReplies(Long postId) {
+        List<TroublePostComment> comments = troublePostCommentRepository.findByRoomTroublePostIdAndIsReplyFalse(postId);
+        return comments.stream()
+                .map(this::convertToCommentDTO)
+                .collect(Collectors.toList());
+    }
+
+    private RoomPostResponseDto.CommentDTO convertToCommentDTO(TroublePostComment comment) {
+        RoomPostResponseDto.CommentDTO dto = new RoomPostResponseDto.CommentDTO();
+        dto.setId(comment.getId());
+        dto.setAuthorName(comment.getUser().getName());
+        dto.setBody(comment.getBody());
+        dto.setCreatedAt(comment.getCreatedAt());
+        dto.setReplies(comment.getReplies().stream()
+                .map(this::convertToCommentDTO)
+                .collect(Collectors.toList()));
+        return dto;
+    }
+
+    public List<RoomPostResponseDto.CommentDTO> getMoreComments(Long postId, Long lastCommentId, int size) {
+        List<TroublePostComment> comments = troublePostCommentRepository
+                .findMoreComments(postId, lastCommentId, PageRequest.of(0, size));
+        return comments.stream()
+                .map(this::convertToCommentDTO)
+                .collect(Collectors.toList());
+    }
+
+    public List<RoomPostResponseDto.CommentDTO> getMoreReplies(Long commentId, Long lastReplyId, int size) {
+        List<TroublePostComment> replies = troublePostCommentRepository
+                .findMoreReplies(commentId, lastReplyId, PageRequest.of(0, size));
+        return replies.stream()
+                .map(this::convertToCommentDTO)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
@@ -173,7 +173,7 @@ public class RoomInfoPostController {
     }
 
     @GetMapping("/info/detail/{postId}")
-    @Operation(summary = "스터디룸 정보나눔 게시글 상세 조회")
+    @Operation(summary = "정보나눔 게시글 상세 조회", description = "1페이지를 불러오고 싶다면 page : 0으로 입력해야 합니다. ex) page 0 > 1페이지 / page 1 > 2페이지 ")
     public BaseResponse<RoomPostResponseDto.RoomInfoPostDetailDTO> getPostDetail(
             @RequestHeader("Authorization") String authorization,
             @PathVariable Long postId,
@@ -185,7 +185,7 @@ public class RoomInfoPostController {
     }
 
     @GetMapping("/info/{postId}/get/comments")
-    @Operation(summary = "스터디룸 정보나눔 게시글 댓글 및 답글 추가 로딩")
+    @Operation(summary = "정보나눔 게시글 댓글 및 답글 추가 로딩", description = "추가로 댓글을 무한 스크롤 형태로 불러올 때 호출하는 api 입니다")
     public BaseResponse<Page<RoomPostResponseDto.CommentWithRepliesDTO>> getMoreComments(
             @PathVariable Long postId,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
@@ -184,7 +184,7 @@ public class RoomInfoPostController {
         return BaseResponse.onSuccess(postDetail);
     }
 
-    @GetMapping("/info/{postId}/comments")
+    @GetMapping("/info/{postId}/get/comments")
     @Operation(summary = "스터디룸 정보나눔 게시글 댓글 및 답글 추가 로딩")
     public BaseResponse<Page<RoomPostResponseDto.CommentWithRepliesDTO>> getMoreComments(
             @PathVariable Long postId,

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -170,4 +172,25 @@ public class RoomInfoPostController {
         return BaseResponse.onSuccess(RoomPostConverter.toWriteInfoPostCommentDto(replyComment));
     }
 
+    @GetMapping("/info/detail/{postId}")
+    @Operation(summary = "스터디룸 정보나눔 게시글 상세 조회")
+    public BaseResponse<RoomPostResponseDto.RoomInfoPostDetailDTO> getPostDetail(
+            @RequestHeader("Authorization") String authorization,
+            @PathVariable Long postId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Long userId = tokenProviderService.getUserIdFromToken(authorization);
+        RoomPostResponseDto.RoomInfoPostDetailDTO postDetail = roomInfoPostQueryService.getPostDetail(postId, userId, page, size);
+        return BaseResponse.onSuccess(postDetail);
+    }
+
+    @GetMapping("/info/{postId}/comments")
+    @Operation(summary = "스터디룸 정보나눔 게시글 댓글 및 답글 추가 로딩")
+    public BaseResponse<Page<RoomPostResponseDto.CommentWithRepliesDTO>> getMoreComments(
+            @PathVariable Long postId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<RoomPostResponseDto.CommentWithRepliesDTO> comments = roomInfoPostQueryService.getCommentsWithReplies(postId, PageRequest.of(page, size));
+        return BaseResponse.onSuccess(comments);
+    }
 }

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomPostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomPostController.java
@@ -13,6 +13,8 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -169,6 +171,28 @@ public class RoomPostController {
         Long userId = tokenProviderService.getUserIdFromToken(authorization);
         PostComment replyComment = roomPostCommandService.addReply(commentId, userId, requestDto);
         return BaseResponse.onSuccess(RoomPostConverter.toWritePostCommentDto(replyComment));
+    }
+
+    @GetMapping("/post/{postId}detail")
+    @Operation(summary = "스터디룸 게시글 상세 조회")
+    public BaseResponse<RoomPostResponseDto.RoomPostDetailDTO> getPostDetail(
+            @PathVariable Long postId,
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Long userId = tokenProviderService.getUserIdFromToken(authorization);
+        RoomPostResponseDto.RoomPostDetailDTO postDetail = roomPostQueryService.getPostDetail(postId, userId, page, size);
+        return BaseResponse.onSuccess(postDetail);
+    }
+
+    @GetMapping("/post/{postId}/get/comments")
+    @Operation(summary = "스터디룸 게시글 댓글 및 답글 추가 로딩")
+    public BaseResponse<Page<RoomPostResponseDto.CommentWithRepliesDTO>> getMoreComments(
+            @PathVariable Long postId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size) {
+        Page<RoomPostResponseDto.CommentWithRepliesDTO> comments = roomPostQueryService.getCommentsWithReplies(postId, PageRequest.of(page, size));
+        return BaseResponse.onSuccess(comments);
     }
 
 }

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomPostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomPostController.java
@@ -174,7 +174,7 @@ public class RoomPostController {
     }
 
     @GetMapping("/post/{postId}detail")
-    @Operation(summary = "스터디룸 게시글 상세 조회")
+    @Operation(summary = "스터디룸 게시글 상세 조회", description = "1페이지를 불러오고 싶다면 page : 0으로 입력해야 합니다. ex) page 0 > 1페이지 / page 1 > 2페이지 ")
     public BaseResponse<RoomPostResponseDto.RoomPostDetailDTO> getPostDetail(
             @PathVariable Long postId,
             @RequestHeader("Authorization") String authorization,
@@ -186,7 +186,7 @@ public class RoomPostController {
     }
 
     @GetMapping("/post/{postId}/get/comments")
-    @Operation(summary = "스터디룸 게시글 댓글 및 답글 추가 로딩")
+    @Operation(summary = "스터디룸 게시글 댓글 및 답글 추가 로딩", description = "추가로 댓글을 무한 스크롤 형태로 불러올 때 호출하는 api 입니다")
     public BaseResponse<Page<RoomPostResponseDto.CommentWithRepliesDTO>> getMoreComments(
             @PathVariable Long postId,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
@@ -13,6 +13,9 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
@@ -169,6 +172,30 @@ public class RoomTroublePostController {
                 roomTroublePostQueryService.getNextTroublePosts(boardId, lastPostId, size);
 
         return BaseResponse.onSuccess(posts);
+    }
+
+    @GetMapping("/rouble/read/{postId}")
+    public BaseResponse<RoomPostResponseDto.TroublePostDetailDTO> getPostDetail(@PathVariable Long postId,
+                                                                                  @AuthenticationPrincipal UserDetails userDetails) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+        RoomPostResponseDto.TroublePostDetailDTO postDetail = roomTroublePostQueryService.getPostDetail(postId, userId);
+        return BaseResponse.onSuccess(postDetail);
+    }
+
+    @GetMapping("/{postId}/comments")
+    public BaseResponse<List<RoomPostResponseDto.CommentDTO>> getMoreComments(@PathVariable Long postId,
+                                                                              @RequestParam Long lastCommentId,
+                                                                              @RequestParam(defaultValue = "10") int size) {
+        List<RoomPostResponseDto.CommentDTO> comments = roomTroublePostQueryService.getMoreComments(postId, lastCommentId, size);
+        return BaseResponse.onSuccess(comments);
+    }
+
+    @GetMapping("/comments/{commentId}/replies")
+    public BaseResponse<List<RoomPostResponseDto.CommentDTO>> getMoreReplies(@PathVariable Long commentId,
+                                                                               @RequestParam Long lastReplyId,
+                                                                               @RequestParam(defaultValue = "10") int size) {
+        List<RoomPostResponseDto.CommentDTO> replies = roomTroublePostQueryService.getMoreReplies(commentId, lastReplyId, size);
+        return BaseResponse.onSuccess(replies);
     }
 }
 

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
@@ -189,7 +189,7 @@ public class RoomTroublePostController {
     }
 
     @GetMapping("/trouble/{postId}/comments")
-    @Operation(summary = "트러블 슈팅 게시글 댓글 및 답글 추가 로딩")
+    @Operation(summary = "트러블 슈팅 게시글 댓글 및 답글 추가 로딩", description = "추가로 댓글을 무한 스크롤 형태로 불러올 때 호출하는 api 입니다")
     public BaseResponse<Page<RoomPostResponseDto.CommentWithRepliesDTO>> getMoreComments(
             @PathVariable Long postId,
             @RequestParam(defaultValue = "0") int page,

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
@@ -177,7 +177,7 @@ public class RoomTroublePostController {
     }
 
     @GetMapping("/trouble/detail/{postId}")
-    @Operation(summary = "트러블 슈팅 게시글 상세 조회")
+    @Operation(summary = "트러블 슈팅 게시글 상세 조회", description = "1페이지를 불러오고 싶다면 page : 0으로 입력해야 합니다. ex) page 0 > 1페이지 / page 1 > 2페이지 ")
     public BaseResponse<RoomPostResponseDto.TroublePostDetailDTO> getPostDetail(
             @RequestHeader("Authorization") String authorization,
             @PathVariable Long postId,

--- a/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
@@ -1,12 +1,10 @@
 package gaji.service.domain.roomBoard.web.dto;
 
 import gaji.service.global.converter.DateConverter;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public class RoomPostResponseDto {
     @Builder
@@ -120,4 +118,29 @@ public class RoomPostResponseDto {
         }
     }
 
+    @Getter
+    @Setter
+    public static class TroublePostDetailDTO {
+        private Long id;
+        private String title;
+        private String body;
+        private String authorName;
+        private LocalDateTime createdAt;
+        private int viewCount;
+        private int likeCount;
+        private int bookmarkCount;
+        private boolean isLiked;
+        private boolean isBookmarked;
+        private List<CommentDTO> comments;
+    }
+
+    @Getter
+    @Setter
+    public static class CommentDTO {
+        private Long id;
+        private String authorName;
+        private String body;
+        private LocalDateTime createdAt;
+        private List<CommentDTO> replies;
+    }
 }

--- a/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
@@ -2,6 +2,7 @@ package gaji.service.domain.roomBoard.web.dto;
 
 import gaji.service.global.converter.DateConverter;
 import lombok.*;
+import org.springframework.data.domain.Page;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -131,7 +132,17 @@ public class RoomPostResponseDto {
         private int bookmarkCount;
         private boolean isLiked;
         private boolean isBookmarked;
-        private List<CommentDTO> comments;
+        private Page<CommentWithRepliesDTO> comments;
+    }
+
+    @Getter
+    @Setter
+    public static class CommentWithRepliesDTO {
+        private Long id;
+        private String authorName;
+        private String body;
+        private LocalDateTime createdAt;
+        private List<CommentDTO> replies;
     }
 
     @Getter
@@ -141,6 +152,12 @@ public class RoomPostResponseDto {
         private String authorName;
         private String body;
         private LocalDateTime createdAt;
-        private List<CommentDTO> replies;
     }
 }
+
+
+
+
+
+
+

--- a/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
@@ -153,6 +153,23 @@ public class RoomPostResponseDto {
         private String body;
         private LocalDateTime createdAt;
     }
+
+    @Getter
+    @Setter
+    public static class RoomInfoPostDetailDTO {
+        private Long id;
+        private String title;
+        private String body;
+        private String authorName;
+        private LocalDateTime createdAt;
+        private int viewCount;
+        private int likeCount;
+        private int bookmarkCount;
+        private boolean isLiked;
+        private boolean isBookmarked;
+        private Page<CommentWithRepliesDTO> comments;
+    }
+
 }
 
 

--- a/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/dto/RoomPostResponseDto.java
@@ -170,6 +170,21 @@ public class RoomPostResponseDto {
         private Page<CommentWithRepliesDTO> comments;
     }
 
+    @Getter
+    @Setter
+    public static class RoomPostDetailDTO {
+        private Long id;
+        private String title;
+        private String body;
+        private String authorName;
+        private LocalDateTime createdAt;
+        private int viewCount;
+        private int likeCount;
+        private int bookmarkCount;
+        private boolean isLiked;
+        private boolean isBookmarked;
+        private Page<CommentWithRepliesDTO> comments;
+    }
 }
 
 


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#116-READ-3POST-API/GAJI-132 -> develop

## 변경 사항
- 트러블슈팅, 정보나눔, 일반 게시글에 대한 상세보기 조회, 댓글의 경우 무한 스크롤 방식 기능을 구현하였습니다.
- 처음 글을 조회했을 땐 게시글과 댓글이 조회되지만
- 추가적인 댓글 조회를 하기 위해서 스크롤 할 때 호출되면 api , 두 개의 api를 생성하였습니다.

## 이슈
- 

## 테스트 결과
- 3개의 게시글 모두 같은 형태로 일반 게시글의 테스트 결과를 보여드리겠습니다.
- 정보나눔, 트러블슈팅 게시글의 경우도 모두 테스트 완료하였습니다.

### 게시글을 상세조회 했을 때 댓글도 같이 조회가 됩니다
### /api/study-rooms/post/{postId}detail
![image](https://github.com/user-attachments/assets/35085578-f392-47c0-aacd-3862cd29555b)


답글이 있는 경우 댓글 안에 답글이 포함되게끔 설정하였습니다.
또한 댓글은 작성된지 오래된 순으로 정렬하였습니다. 오래된 댓글이 가장 위에 위치합니다.
![image](https://github.com/user-attachments/assets/d6815886-65c6-4637-9620-d919ae9914aa)


### 댓글을 추가적으로 무한 스크롤 할 경우
### /api/study-rooms/post/{postId}/get/comments
![image](https://github.com/user-attachments/assets/edec72ae-3b07-4dd4-911d-44d0fbd187a2)


