### PR TITLE
✨ [feature] 회원가입 완료 시에 닉네임 설정하는 창으로 redirect 하는 기능 구현

### DIFF
--- a/src/main/java/gaji/service/ServiceApplication.java
+++ b/src/main/java/gaji/service/ServiceApplication.java
@@ -1,9 +1,7 @@
 package gaji.service;
 
 import org.springframework.boot.SpringApplication;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 

--- a/src/main/java/gaji/service/config/SecurityConfig.java
+++ b/src/main/java/gaji/service/config/SecurityConfig.java
@@ -6,7 +6,6 @@ import gaji.service.jwt.filter.JWTUtil;
 import gaji.service.jwt.rpository.RefreshRepository;
 import gaji.service.jwt.service.CustomSuccessHandler;
 import gaji.service.oauth2.service.CustomOAuth2UserService;
-import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,7 +20,6 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
-import java.util.Collections;
 
 @Configuration
 @EnableWebSecurity

--- a/src/main/java/gaji/service/config/WebConfig.java
+++ b/src/main/java/gaji/service/config/WebConfig.java
@@ -1,11 +1,10 @@
 package gaji.service.config;
 
-import gaji.service.domain.recruit.converter.CategoryConverter;
-import gaji.service.domain.recruit.converter.FilterConverter;
-import gaji.service.domain.post.converter.SortTypeConverter;
 import gaji.service.domain.post.converter.PostStatusConverter;
 import gaji.service.domain.post.converter.PostTypeConverter;
-
+import gaji.service.domain.post.converter.SortTypeConverter;
+import gaji.service.domain.recruit.converter.CategoryConverter;
+import gaji.service.domain.recruit.converter.FilterConverter;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;

--- a/src/main/java/gaji/service/domain/room/entity/Room.java
+++ b/src/main/java/gaji/service/domain/room/entity/Room.java
@@ -1,7 +1,6 @@
 package gaji.service.domain.room.entity;
 
 import gaji.service.domain.common.entity.BaseEntity;
-import gaji.service.domain.curriculum.Curriculum;
 import gaji.service.domain.enums.RecruitPostTypeEnum;
 import gaji.service.domain.recruit.entity.RecruitPostBookmark;
 import gaji.service.domain.recruit.entity.RecruitPostLikes;

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/RoomInfoPostRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/RoomInfoPostRepository.java
@@ -1,9 +1,7 @@
 package gaji.service.domain.roomBoard.repository.RoomInfo;
 
-import gaji.service.domain.roomBoard.entity.RoomInfo.InfoPostComment;
 import gaji.service.domain.roomBoard.entity.RoomInfo.RoomInfoPost;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
@@ -2,7 +2,6 @@ package gaji.service.domain.roomBoard.repository.RoomTrouble;
 
 import gaji.service.domain.roomBoard.entity.RoomTrouble.TroublePostComment;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
@@ -15,9 +15,6 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;

--- a/src/main/java/gaji/service/domain/user/service/UserCommandService.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandService.java
@@ -7,4 +7,6 @@ public interface UserCommandService {
     public User cancleUser(Long userId);
     public User updateUserNickname(Long userIdFromToken, Long userIdFromPathVariable, UserRequestDTO.UpdateNicknameDTO request);
     public void hardDeleteInactiveUsers();
+    void save(User user);
+
 }

--- a/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserCommandServiceImpl.java
@@ -62,4 +62,9 @@ public class UserCommandServiceImpl implements UserCommandService{
                 .minusDays(UserDeletePeriod.ONE_MONTH.getDays());
         userRepository.deleteAllByInactiveTimeBefore(cutoffDate);
     }
+
+    @Override
+    public void save(User user) {
+        userRepository.save(user);
+    }
 }

--- a/src/main/java/gaji/service/domain/user/service/UserQueryService.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryService.java
@@ -17,4 +17,6 @@ public interface UserQueryService {
     Slice<Tuple> getUserRoomList(Long userId, LocalDate cursorDate, Long cursorId, RoomTypeEnum type, int size);
     User getUserDetail(Long userId);
     Slice<Tuple> getUserPostList(Long userId, LocalDateTime cursorDateTime, PostTypeEnum type, int size);
+
+    User findByUsernameId(String usernameId);
 }

--- a/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
@@ -79,4 +79,9 @@ public class UserQueryServiceImpl implements UserQueryService {
 
         return postList;
     }
+
+    @Override
+    public User findByUsernameId(String usernameId) {
+        return userRepository.findByUsernameId(usernameId);
+    }
 }

--- a/src/main/java/gaji/service/global/util/uuid/Uuid.java
+++ b/src/main/java/gaji/service/global/util/uuid/Uuid.java
@@ -1,7 +1,10 @@
 package gaji.service.global.util.uuid;
 
 import jakarta.persistence.*;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter

--- a/src/main/java/gaji/service/jwt/filter/JWTFilter.java
+++ b/src/main/java/gaji/service/jwt/filter/JWTFilter.java
@@ -1,6 +1,5 @@
 package gaji.service.jwt.filter;
 
-import gaji.service.domain.enums.Role;
 import gaji.service.domain.enums.ServiceRole;
 import gaji.service.oauth2.dto.CustomOAuth2User;
 import gaji.service.oauth2.dto.OAuthUserDTO;

--- a/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
+++ b/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
@@ -35,6 +35,11 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Value("${redirectionUrl}")
     private String redirectionUrl;
 
+    @Value("${nicknameRedirectionUrl}")
+    private String nicknameRedirectionUrl;
+
+    private String finalRedirectionUrl;
+
     public CustomSuccessHandler(JWTUtil jwtUtil, RefreshRepository refreshRepository, ObjectMapper objectMapper) {
         this.jwtUtil = jwtUtil;
         this.refreshRepository = refreshRepository;
@@ -86,8 +91,17 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         log.info("accessToken = {}", accessToken);
         log.info("refreshToken = {}", refreshToken);
 
+
+        if (customUserDetails.isNewUser()) {
+            finalRedirectionUrl = this.nicknameRedirectionUrl;
+
+        } else {
+            finalRedirectionUrl = this.redirectionUrl;
+        }
+
+
         // 리다이렉션 URL 생성
-        String targetUrl = UriComponentsBuilder.fromUriString(redirectionUrl)
+        String targetUrl = UriComponentsBuilder.fromUriString(finalRedirectionUrl)
                 .queryParam("access_token", accessToken)
                 .build().toUriString();
 

--- a/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
+++ b/src/main/java/gaji/service/jwt/service/CustomSuccessHandler.java
@@ -9,9 +9,8 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-
-import org.springframework.beans.factory.annotation.Value;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
@@ -38,8 +37,6 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Value("${nicknameRedirectionUrl}")
     private String nicknameRedirectionUrl;
 
-    private String finalRedirectionUrl;
-
     public CustomSuccessHandler(JWTUtil jwtUtil, RefreshRepository refreshRepository, ObjectMapper objectMapper) {
         this.jwtUtil = jwtUtil;
         this.refreshRepository = refreshRepository;
@@ -49,6 +46,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
         String usernameId = customUserDetails.getName();
         String role = authentication.getAuthorities().stream()
                 .findFirst()
@@ -92,6 +90,7 @@ public class CustomSuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         log.info("refreshToken = {}", refreshToken);
 
 
+        String finalRedirectionUrl;
         if (customUserDetails.isNewUser()) {
             finalRedirectionUrl = this.nicknameRedirectionUrl;
 

--- a/src/main/java/gaji/service/oauth2/controller/Test2Controller.java
+++ b/src/main/java/gaji/service/oauth2/controller/Test2Controller.java
@@ -1,6 +1,5 @@
 package gaji.service.oauth2.controller;
 
-import gaji.service.domain.enums.Role;
 import gaji.service.domain.enums.ServiceRole;
 import gaji.service.jwt.filter.JWTUtil;
 import gaji.service.jwt.service.CustomSuccessHandler;

--- a/src/main/java/gaji/service/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/gaji/service/oauth2/dto/CustomOAuth2User.java
@@ -10,10 +10,14 @@ import java.util.Map;
 public class CustomOAuth2User implements OAuth2User {
 
     private final OAuthUserDTO oAuthUserDTO;
+    private final boolean isNewUser;
+
 
     public CustomOAuth2User(OAuthUserDTO oAuthUserDTO) {
 
         this.oAuthUserDTO = oAuthUserDTO;
+        this.isNewUser = oAuthUserDTO.isNewUser();
+
     }
 
     @Override
@@ -44,6 +48,9 @@ public class CustomOAuth2User implements OAuth2User {
         return oAuthUserDTO.getUsernameId();
     }
 
+    public boolean isNewUser() {
+        return isNewUser;
+    }
 //    public String getUsernameId() {
 //
 //        return oAuthUserDTO.getUsernameId();

--- a/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
@@ -1,8 +1,10 @@
 package gaji.service.oauth2.dto;
 
-import gaji.service.domain.enums.Role;
 import gaji.service.domain.enums.ServiceRole;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter

--- a/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/OAuthUserDTO.java
@@ -2,17 +2,17 @@ package gaji.service.oauth2.dto;
 
 import gaji.service.domain.enums.Role;
 import gaji.service.domain.enums.ServiceRole;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
+@AllArgsConstructor
+@NoArgsConstructor
 public class OAuthUserDTO {
 
     private ServiceRole role;
     private String name;
     // 서버에서 발급받는 아이디
     private String usernameId;
-
-
+    private boolean isNewUser;
 }

--- a/src/main/java/gaji/service/oauth2/dto/TransferUserDTO.java
+++ b/src/main/java/gaji/service/oauth2/dto/TransferUserDTO.java
@@ -1,6 +1,9 @@
 package gaji.service.oauth2.dto;
 
-import gaji.service.domain.enums.*;
+import gaji.service.domain.enums.Gender;
+import gaji.service.domain.enums.ServiceRole;
+import gaji.service.domain.enums.SocialType;
+import gaji.service.domain.enums.UserActive;
 import lombok.Getter;
 import lombok.Setter;
 

--- a/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/gaji/service/oauth2/service/CustomOAuth2UserService.java
@@ -1,9 +1,11 @@
 package gaji.service.oauth2.service;
 
 
-import gaji.service.domain.enums.*;
+import gaji.service.domain.enums.Gender;
+import gaji.service.domain.enums.ServiceRole;
+import gaji.service.domain.enums.SocialType;
+import gaji.service.domain.enums.UserActive;
 import gaji.service.domain.user.entity.User;
-import gaji.service.domain.user.repository.UserRepository;
 import gaji.service.domain.user.service.UserCommandService;
 import gaji.service.domain.user.service.UserQueryService;
 import gaji.service.oauth2.dto.CustomOAuth2User;
@@ -57,10 +59,11 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         if (existData == null) {
 
+            isNewUser = true;
             OAuthUserDTO oAuthuserDTO = new OAuthUserDTO();
             oAuthuserDTO.setUsernameId(usernameId);
             oAuthuserDTO.setRole(ServiceRole.ROLE_USER);
-            isNewUser = true;
+            oAuthuserDTO.setNewUser(isNewUser);
 
             if (registrationId.equals("naver")) {
 
@@ -99,7 +102,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             return new CustomOAuth2User(oAuthuserDTO);
 
         }else{
-
             existData.setEmail(oAuth2Response.getEmail());
             existData.setName(oAuth2Response.getName());
 


### PR DESCRIPTION
처음 회원가입 하는 회원이라면 닉네임 설정하는 곳으로, 기존 회원이라면 메인 화면으로 리디렉션

## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#119-REDIRECT-NICKNAME-SETTING/GAJI-133 -> develop

## 변경 사항
- 기존 회원인지 아닌지에 따라 로그인 했을 때 리디렉션 위치를 다르게 했습니다.
- 회원가입 : 닉네임 설정하는 url
- 로그인 : 메인화면 url
## 이슈
- 

## 테스트 결과
- 테스트를 위해 로그인 시  http://localhost:3000/ok 로 리디렉션 (yml 파일에 있는 url을 가져옴. ok 는 테스트를 위한 url)

- 테스트를 위해 회원가입 시 http://localhost:3000/redirect 로 리디렉션 (닉네임 설정)

- 해당 url은 테스트를 위한 임의의 url임
![image](https://github.com/user-attachments/assets/91c3e323-966b-4dfd-afac-b75b8db0f3dd)


### 회원가입 할 때
![image](https://github.com/user-attachments/assets/c18afd85-1b61-44a6-b5f1-36ad11da062a)

### 로그인 할 때 
![image](https://github.com/user-attachments/assets/8d8395c5-e3f3-4b85-b53f-d05810085f02)

