### PR TITLE
:art: [Fix] #67 - 스터디룸 가져오기 API 수정

### DIFF
--- a/src/main/java/gaji/service/domain/post/repository/CommunityPostQueryDslRepositoryImpl.java
+++ b/src/main/java/gaji/service/domain/post/repository/CommunityPostQueryDslRepositoryImpl.java
@@ -139,7 +139,7 @@ public class CommunityPostQueryDslRepositoryImpl implements CommunityPostQueryDs
     private OrderSpecifier orderBySortType(SortType sortTypeCond) {
         return switch (sortTypeCond) {
             case HOT -> commnuityPost.popularityScore.desc(); // HOT: 인기점수 내림차순
-            case LIKE -> commnuityPost.createdAt.desc(); // LIKE: 좋아요 내림차순
+            case LIKE -> commnuityPost.likeCnt.desc(); // LIKE: 좋아요 내림차순
             case HIT -> commnuityPost.hit.desc(); // HIT: 조회수 내림차순
             default -> commnuityPost.createdAt.desc(); // null or RECENT: 최신순(생성일자 내림차순)
         };

--- a/src/main/java/gaji/service/domain/room/repository/RoomCustomRepository.java
+++ b/src/main/java/gaji/service/domain/room/repository/RoomCustomRepository.java
@@ -9,5 +9,7 @@ import java.time.LocalDate;
 
 public interface RoomCustomRepository {
     public Slice<Tuple> findAllOngoingRoomsByUser(User user, LocalDate cursorDate, Long cursorId, Pageable pageable);
+    public Slice<Tuple> findAllOngoingRoomsByUser(User user, Pageable pageable);
     public Slice<Tuple> findAllEndedRoomsByUser(User user, LocalDate cursorDate, Long cursorId, Pageable pageable);
+    public Slice<Tuple> findAllEndedRoomsByUser(User user, Pageable pageable);
 }

--- a/src/main/java/gaji/service/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/gaji/service/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -34,7 +34,6 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
                 .from(room)
                 .where(room.id.in(userRoomIds)
                         .and(room.studyEndDay.after(getCurrentDay()))
-                        .and(room.studyStartDay.before(getCurrentDay()).or(room.studyStartDay.goe(getCurrentDay())))  // 시작일이 현재 날짜 이전이거나 이후인 경우 포함
                         .and(getCursorCondition(cursorDate, cursorId)))
                 .orderBy(room.studyStartDay.desc(), room.id.asc())
                 .limit(pageable.getPageSize()+1) // size보다 1개 더 가져와서 다음 페이지 여부 확인
@@ -43,13 +42,7 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
         return checkLastPage(pageable, ongoingRooms);
     }
 
-
-    public Slice<Tuple> findAllEndedRoomsByUser(User user, LocalDate cursorDate, Long cursorId, Pageable pageable) {
-        LocalDate now = LocalDate.now();
-
-        BooleanExpression cursorCondition = (room.studyStartDay.eq(cursorDate).and(room.id.gt(cursorId)))
-                .or(room.studyStartDay.lt(cursorDate));
-
+    public Slice<Tuple> findAllOngoingRoomsByUser(User user, Pageable pageable) {
         List<Long> userRoomIds = jpaQueryFactory
                 .select(studyMate.room.id)
                 .from(studyMate)
@@ -59,13 +52,50 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
         List<Tuple> ongoingRooms = jpaQueryFactory.select(room.id, room.name, room.description, room.thumbnailUrl, room.studyStartDay)
                 .from(room)
                 .where(room.id.in(userRoomIds)
+                        .and(room.studyEndDay.after(getCurrentDay())))
+                .orderBy(room.studyStartDay.desc(), room.id.asc())
+                .limit(pageable.getPageSize()+1) // size보다 1개 더 가져와서 다음 페이지 여부 확인
+                .fetch();
+
+        return checkLastPage(pageable, ongoingRooms);
+    }
+
+
+    public Slice<Tuple> findAllEndedRoomsByUser(User user, LocalDate cursorDate, Long cursorId, Pageable pageable) {
+        List<Long> userRoomIds = jpaQueryFactory
+                .select(studyMate.room.id)
+                .from(studyMate)
+                .where(studyMate.user.eq(user))
+                .fetch();
+
+        List<Tuple> endedRooms = jpaQueryFactory.select(room.id, room.name, room.description, room.thumbnailUrl, room.studyStartDay)
+                .from(room)
+                .where(room.id.in(userRoomIds)
                         .and(room.studyEndDay.before(getCurrentDay()))
                         .and(getCursorCondition(cursorDate, cursorId)))
                 .orderBy(room.studyStartDay.desc(), room.id.asc())
                 .limit(pageable.getPageSize()+1) // size보다 1개 더 가져와서 다음 페이지 여부 확인
                 .fetch();
 
-        return checkLastPage(pageable, ongoingRooms);
+        return checkLastPage(pageable, endedRooms);
+    }
+
+    public Slice<Tuple> findAllEndedRoomsByUser(User user, Pageable pageable) {
+        List<Long> userRoomIds = jpaQueryFactory
+                .select(studyMate.room.id)
+                .from(studyMate)
+                .where(studyMate.user.eq(user))
+                .fetch();
+
+        List<Tuple> endedRooms = jpaQueryFactory.select(room.id, room.name, room.description, room.thumbnailUrl, room.studyStartDay)
+                .from(room)
+                .where(room.id.in(userRoomIds)
+                        .and(room.studyEndDay.before(getCurrentDay())))
+                .orderBy(room.studyStartDay.desc(), room.id.asc())
+                .limit(pageable.getPageSize()+1) // size보다 1개 더 가져와서 다음 페이지 여부 확인
+                .fetch();
+
+        return checkLastPage(pageable, endedRooms);
     }
 
 

--- a/src/main/java/gaji/service/domain/room/repository/RoomCustomRepositoryImpl.java
+++ b/src/main/java/gaji/service/domain/room/repository/RoomCustomRepositoryImpl.java
@@ -33,7 +33,7 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
         List<Tuple> ongoingRooms = jpaQueryFactory.select(room.id, room.name, room.description, room.thumbnailUrl, room.studyStartDay)
                 .from(room)
                 .where(room.id.in(userRoomIds)
-                        .and(room.studyEndDay.after(getCurrentDay()))
+                        .and(room.studyEndDay.after(getCurrentDay().minusDays(1)))
                         .and(getCursorCondition(cursorDate, cursorId)))
                 .orderBy(room.studyStartDay.desc(), room.id.asc())
                 .limit(pageable.getPageSize()+1) // size보다 1개 더 가져와서 다음 페이지 여부 확인
@@ -52,7 +52,7 @@ public class RoomCustomRepositoryImpl implements RoomCustomRepository {
         List<Tuple> ongoingRooms = jpaQueryFactory.select(room.id, room.name, room.description, room.thumbnailUrl, room.studyStartDay)
                 .from(room)
                 .where(room.id.in(userRoomIds)
-                        .and(room.studyEndDay.after(getCurrentDay())))
+                        .and(room.studyEndDay.after(getCurrentDay().minusDays(1))))
                 .orderBy(room.studyStartDay.desc(), room.id.asc())
                 .limit(pageable.getPageSize()+1) // size보다 1개 더 가져와서 다음 페이지 여부 확인
                 .fetch();

--- a/src/main/java/gaji/service/domain/roomBoard/entity/RoomBoard.java
+++ b/src/main/java/gaji/service/domain/roomBoard/entity/RoomBoard.java
@@ -26,6 +26,7 @@ public class RoomBoard {
     @JoinColumn(name = "room_id")
     private Room room;
 
+    //추후 삭제합시다. RoomPostType으로 한정된 게시판을 관리한다면 필요 없을거같습니다.
     private String name;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/user/service/UserQueryServiceImpl.java
@@ -49,18 +49,25 @@ public class UserQueryServiceImpl implements UserQueryService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new RestApiException(UserErrorStatus._USER_NOT_FOUND));
 
-        cursorDate = cursorDate == null ? LocalDate.now() : cursorDate;
-        cursorId = cursorId == null ? 0 : cursorId;
-
         PageRequest pageRequest = PageRequest.of(0, size);
 
         Slice<Tuple> roomList;
 
         if(type == RoomTypeEnum.ONGOING) {
-            roomList = roomCustomRepository.findAllOngoingRoomsByUser(user, cursorDate, cursorId, pageRequest);
+            if(cursorId != null || cursorDate != null) {
+                roomList = roomCustomRepository.findAllOngoingRoomsByUser(user, cursorDate, cursorId, pageRequest);
+            }
+            else {
+                roomList = roomCustomRepository.findAllOngoingRoomsByUser(user, pageRequest);
+            }
         }
         else{
-            roomList = roomCustomRepository.findAllEndedRoomsByUser(user, cursorDate, cursorId, pageRequest);
+            if(cursorId != null || cursorDate != null) {
+                roomList = roomCustomRepository.findAllEndedRoomsByUser(user, cursorDate, cursorId, pageRequest);
+            }
+            else {
+                roomList = roomCustomRepository.findAllEndedRoomsByUser(user, pageRequest);
+            }
         }
 
         return roomList;


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [x] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
feature/#67-user-studyroom/GAJI-98 -> develop

## 변경 사항
사용자의 진행중인 스터디룸을 가져올 시, 미래에 시작될 스터디룸도 가져오도록 수정하였습니다.

## 이슈
- 

## 테스트 결과
![캡처](https://github.com/user-attachments/assets/d042d2c6-f3bf-4d1a-af6c-164567faa463)

