### PR TITLE
♻️ [refactor] 스터디룸 게시글(트러블슈팅 게시글, 게시글, 정보나눔 게시글) pathvriable 을 roomId 형태로 변경

### DIFF
--- a/src/main/java/gaji/service/domain/room/repository/RoomEventRepository.java
+++ b/src/main/java/gaji/service/domain/room/repository/RoomEventRepository.java
@@ -15,6 +15,4 @@ public interface RoomEventRepository extends JpaRepository<RoomEvent,Long> {
     Optional<RoomEvent> findRoomEventById(Long roomId);
 
     List<RoomEvent> findByRoom(Room room);
-
-    int countByRoomId(Long roomId);
 }

--- a/src/main/java/gaji/service/domain/room/repository/RoomNoticeRepository.java
+++ b/src/main/java/gaji/service/domain/room/repository/RoomNoticeRepository.java
@@ -1,18 +1,36 @@
 package gaji.service.domain.room.repository;
 
 import gaji.service.domain.room.entity.RoomNotice;
+import gaji.service.domain.room.web.dto.RoomResponseDto;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomNoticeRepository extends JpaRepository<RoomNotice, Long> {
-    @Modifying
-    @Query("UPDATE RoomNotice rn SET rn.confirmCount = rn.confirmCount + 1 WHERE rn.id = :noticeId")
-    void incrementConfirmCount(Long noticeId);
+    @Query("SELECT NEW gaji.service.domain.room.web.dto.RoomResponseDto$NoticeDto(" +
+            "rn.id, sm.user.name, rn.title, rn.body, CAST(COUNT(nc) AS Long), rn.createdAt, rn.viewCount) " +
+            "FROM RoomNotice rn " +
+            "JOIN rn.studyMate sm " +
+            "LEFT JOIN NoticeConfirmation nc ON nc.roomNotice.id = rn.id " +
+            "WHERE sm.room.id = :roomId AND rn.createdAt <= :lastCreatedAt " +
+            "GROUP BY rn.id, sm.user.name, rn.title, rn.body, rn.createdAt, rn.viewCount " +
+            "ORDER BY rn.createdAt DESC, rn.id DESC")
+    List<RoomResponseDto.NoticeDto> findNoticeSummariesForInfiniteScroll(
+            @Param("roomId") Long roomId,
+            @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
+            Pageable pageable);
 
-    @Modifying
-    @Query("UPDATE RoomNotice rn SET rn.confirmCount = rn.confirmCount - 1 WHERE rn.id = :noticeId AND rn.confirmCount > 0")
-    void decrementConfirmCount(Long noticeId);
+    @Query("SELECT CASE " +
+            "WHEN EXISTS (SELECT 1 FROM RoomNotice rn WHERE rn.studyMate.room.id = :roomId AND rn.id = :noticeId) " +
+            "THEN (SELECT rn.createdAt FROM RoomNotice rn WHERE rn.studyMate.room.id = :roomId AND rn.id = :noticeId) " +
+            "ELSE (SELECT MAX(rn.createdAt) FROM RoomNotice rn WHERE rn.studyMate.room.id = :roomId) " +
+            "END")
+    Optional<LocalDateTime> findCreatedAtByIdOrEarliest(@Param("roomId") Long roomId, @Param("noticeId") Long noticeId);
 }

--- a/src/main/java/gaji/service/domain/room/service/RoomQueryService.java
+++ b/src/main/java/gaji/service/domain/room/service/RoomQueryService.java
@@ -3,7 +3,6 @@ package gaji.service.domain.room.service;
 import gaji.service.domain.room.entity.Room;
 import gaji.service.domain.room.entity.RoomEvent;
 import gaji.service.domain.room.web.dto.RoomResponseDto;
-import gaji.service.domain.user.entity.User;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -14,9 +13,13 @@ public interface RoomQueryService {
 
     RoomEvent findRoomEventByRoomIdAndWeeks(Long roomId, Integer weeks);
 
-    List<RoomResponseDto.NoticeDto> getNotices(Long roomId, int page, int size);
+//    List<RoomResponseDto.NoticeDto> getNotices(Long roomId, int page, int size);
+//
+//    RoomResponseDto.NoticeDto getNoticeDetail(Long roomId, Long noticeId);
+//
+//    List<RoomResponseDto.NoticeDto> getNextNotices(Long roomId, Long lastNoticeId, int size);
 
-    RoomResponseDto.NoticeDto getNoticeDetail(Long roomId, Long noticeId);
+    List<RoomResponseDto.NoticeDto> getNextNotices(Long roomId, Long lastNoticeId, int size);
 
     @Transactional(readOnly = true)
     RoomResponseDto.WeeklyStudyInfoDTO getWeeklyStudyInfo(Long roomId, Integer weeks);

--- a/src/main/java/gaji/service/domain/room/service/RoomQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/room/service/RoomQueryServiceImpl.java
@@ -6,14 +6,17 @@ import gaji.service.domain.room.entity.Room;
 import gaji.service.domain.room.entity.RoomEvent;
 import gaji.service.domain.room.repository.*;
 import gaji.service.domain.room.web.dto.RoomResponseDto;
-import gaji.service.domain.user.entity.User;
+import gaji.service.global.converter.DateConverter;
 import gaji.service.global.exception.RestApiException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.security.web.access.WebInvocationPrivilegeEvaluator;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.webjars.NotFoundException;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,6 +32,7 @@ public class RoomQueryServiceImpl implements RoomQueryService {
     private final WeeklyUserProgressRepository weeklyUserProgressRepository;
     private final NoticeConfirmationRepository noticeConfirmationRepository;
     private final WebInvocationPrivilegeEvaluator privilegeEvaluator;
+    private final RoomNoticeRepository roomNoticeRepository;
 
     //    @Override
 //    public RoomEvent findRoomEventById(Long roomId){
@@ -49,28 +53,32 @@ public Room findRoomById(Long roomId) {
                 .orElseThrow(() -> new RestApiException(RoomErrorStatus._ROOM_EVENT_NOT_FOUND));
     }
 
-    @Override
-    public List<RoomResponseDto.NoticeDto> getNotices(Long roomId, int page, int size) {
-        return roomQueryRepository.getNotices(roomId, page, size);
-    }
+//    @Override
+//    public List<RoomResponseDto.NoticeDto> getNotices(Long roomId, int page, int size) {
+//        return roomQueryRepository.getNotices(roomId, page, size);
+//    }
 
     @Override
-    @Transactional(readOnly = false) // readOnly = false로 설정
-    public RoomResponseDto.NoticeDto getNoticeDetail(Long roomId, Long noticeId) {
-        RoomResponseDto.NoticeDto notice = roomQueryRepository.getNotices(roomId, 1, Integer.MAX_VALUE).stream()
-                .filter(n -> n.getId().equals(noticeId))
-                .findFirst()
-                .orElseThrow(() -> new NotFoundException("Notice not found"));
+    public List<RoomResponseDto.NoticeDto> getNextNotices(Long roomId, Long lastNoticeId, int size) {
+        LocalDateTime lastCreatedAt;
+        if (lastNoticeId == 0) {
+            lastCreatedAt = LocalDateTime.now();
+        } else {
+            lastCreatedAt = roomNoticeRepository.findCreatedAtByIdOrEarliest(roomId, lastNoticeId)
+                    .orElseThrow(() -> new RestApiException(RoomErrorStatus._NOTICE_NOT_FOUND));
+        }
 
-        // viewCount 증가
-        roomQueryRepository.incrementViewCount (noticeId);
+        Sort sort = Sort.by(Sort.Direction.DESC, "createdAt", "id");
+        Pageable pageable = PageRequest.of(0, size, sort);
 
-        // 증가된 viewCount를 반영하기 위해 notice 객체 업데이트
-        notice.setViewCount(notice.getViewCount() + 1);
+        List<RoomResponseDto.NoticeDto> notices = roomNoticeRepository.findNoticeSummariesForInfiniteScroll(roomId, lastCreatedAt, pageable);
 
-        return notice;
+        LocalDateTime now = LocalDateTime.now();
+        for (RoomResponseDto.NoticeDto notice : notices) {
+            notice.setTimeSincePosted(DateConverter.convertToRelativeTimeFormat(notice.getCreatedAt()));
+        }
+        return notices;
     }
-
     @Override
     @Transactional(readOnly = true)
     public RoomResponseDto.WeeklyStudyInfoDTO getWeeklyStudyInfo(Long roomId, Integer weeks) {
@@ -105,7 +113,7 @@ public Room findRoomById(Long roomId) {
     public RoomResponseDto.RoomMainDto getMainStudyRoom(Long roomId) {
 
         RoomResponseDto.RoomMainDto mainStudyRoom = roomQueryRepository.getMainStudyRoom(roomId);
-        return mainStudyRoom.setWeekCount(roomEventRepository.countByRoomId(roomId));
+        return mainStudyRoom;
     }
 
     @Override

--- a/src/main/java/gaji/service/domain/room/web/controller/RoomNoticeController.java
+++ b/src/main/java/gaji/service/domain/room/web/controller/RoomNoticeController.java
@@ -9,6 +9,8 @@ import gaji.service.domain.room.web.dto.RoomResponseDto;
 import gaji.service.global.base.BaseResponse;
 import gaji.service.jwt.service.TokenProviderService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -40,16 +42,16 @@ public class RoomNoticeController {
     }
 
     @GetMapping("/{roomId}/notices")
-    @Operation(summary = "스터디룸 공지 목록 조회 API")
-    public BaseResponse<RoomResponseDto.NoticeDtoList> getNotices(
-            @PathVariable Long roomId,
-            @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "5") int size) {
-        List<RoomResponseDto.NoticeDto> notices = roomQueryService.getNotices(roomId, page, size);
-        return BaseResponse.onSuccess(
-                new RoomResponseDto.NoticeDtoList(notices)
-        );
+    @Operation(summary = "스터디룸 공지 무한 스크롤 조회", description = "공지를 무한 스크롤 방식으로 조회합니다.")
+    @ApiResponse(responseCode = "200", description = "조회 성공")
+    public BaseResponse<List<RoomResponseDto.NoticeDto>> getNextNotices(
+            @PathVariable @Parameter(description = "스터디룸 ID") Long roomId,
+            @RequestParam @Parameter(description = "마지막으로 로드된 공지 ID") Long lastNoticeId,
+            @RequestParam(defaultValue = "5") @Parameter(description = "조회할 공지 수") int size) {
+        List<RoomResponseDto.NoticeDto> notices = roomQueryService.getNextNotices(roomId, lastNoticeId, size);
+        return BaseResponse.onSuccess(notices);
     }
+
 
 //    @GetMapping("/notice/{noticeId}")
 //    @Operation(summary = "특정 공지사항을 조회하는 API")

--- a/src/main/java/gaji/service/domain/room/web/dto/RoomResponseDto.java
+++ b/src/main/java/gaji/service/domain/room/web/dto/RoomResponseDto.java
@@ -110,7 +110,6 @@ public class RoomResponseDto {
     @Builder
     @Getter
     @NoArgsConstructor
-    @AllArgsConstructor
     public static class RoomMainDto {
         private String name;
         private LocalDate startDay;
@@ -119,7 +118,6 @@ public class RoomResponseDto {
         private LocalDate recruitEndDay;
         private Long daysLeftForRecruit;
         private Long applicantCount;
-        private int weekCount;
 
         public RoomMainDto(String name, LocalDate startDay, LocalDate endDay,
                            LocalDate recruitStartDay, LocalDate recruitEndDay,
@@ -132,12 +130,6 @@ public class RoomResponseDto {
             this.applicantCount = applicantCount;
             this.daysLeftForRecruit = Math.max(daysLeftForRecruit, 0L);
         }
-
-        public RoomMainDto setWeekCount(int weekCount){
-            this.weekCount=weekCount;
-            return this;
-        }
-
     }
 
     @Builder

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomBoardRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomBoardRepository.java
@@ -1,5 +1,6 @@
 package gaji.service.domain.roomBoard.repository;
 
+import gaji.service.domain.enums.RoomPostType;
 import gaji.service.domain.roomBoard.entity.RoomBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,6 @@ import java.util.Optional;
 
 @Repository
 public interface RoomBoardRepository extends JpaRepository<RoomBoard, Long> {
+    Optional<RoomBoard> findRoomBoardByRoomIdAndRoomPostType(Long roomId, RoomPostType roomPostType);
     Optional<RoomBoard> findByRoomId(Long roomId);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/RoomInfoPostRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomInfo/RoomInfoPostRepository.java
@@ -8,18 +8,26 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomInfoPostRepository extends JpaRepository<RoomInfoPost, Long> {
     @Query("SELECT new gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto$InfoPostSummaryDto(" +
             "r.id, r.title, r.studyMate.user.nickname, r.createdAt, r.viewCount, SIZE(r.infoPostCommentList)) " +
             "FROM RoomInfoPost r " +
-            "WHERE r.roomBoard.id = :boardId AND r.id < :lastPostId " +
-            "ORDER BY r.createdAt DESC")
+            "WHERE r.roomBoard.id = :boardId AND r.createdAt <= :lastCreatedAt " +
+            "ORDER BY r.createdAt DESC, r.id DESC")
     List<RoomPostResponseDto.InfoPostSummaryDto> findInfoPostSummariesForInfiniteScroll(
             @Param("boardId") Long boardId,
-            @Param("lastPostId") Long lastPostId,
+            @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
             Pageable pageable);
 
+    @Query("SELECT CASE " +
+            "WHEN EXISTS (SELECT 1 FROM RoomInfoPost r WHERE r.roomBoard.id = :boardId AND r.id = :postId) " +
+            "THEN (SELECT r.createdAt FROM RoomInfoPost r WHERE r.roomBoard.id = :boardId AND r.id = :postId) " +
+            "ELSE (SELECT MAX(r.createdAt) FROM RoomInfoPost r WHERE r.roomBoard.id = :boardId) " +
+            "END")
+    Optional<LocalDateTime> findCreatedAtByIdOrEarliest(@Param("boardId") Long boardId, @Param("postId") Long postId);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomPost/RoomPostRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomPost/RoomPostRepository.java
@@ -30,4 +30,5 @@ public interface RoomPostRepository extends JpaRepository<RoomPost, Long> {
             "ELSE (SELECT MAX(r.createdAt) FROM RoomPost r WHERE r.roomBoard.id = :boardId) " +
             "END")
     Optional<LocalDateTime> findCreatedAtByIdOrEarliest(@Param("boardId") Long boardId, @Param("postId") Long postId);
+
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomPost/RoomPostRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomPost/RoomPostRepository.java
@@ -8,17 +8,26 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomPostRepository extends JpaRepository<RoomPost, Long> {
     @Query("SELECT new gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto$PostSummaryDto(" +
             "r.id, r.title, r.studyMate.user.nickname, r.createdAt, r.viewCount, SIZE(r.postCommentList)) " +
             "FROM RoomPost r " +
-            "WHERE r.roomBoard.id = :boardId AND r.id < :lastPostId " +
-            "ORDER BY r.createdAt DESC")
+            "WHERE r.roomBoard.id = :boardId AND r.createdAt <= :lastCreatedAt " +
+            "ORDER BY r.createdAt DESC, r.id DESC")
     List<PostSummaryDto> findPostSummariesForInfiniteScroll(
             @Param("boardId") Long boardId,
-            @Param("lastPostId") Long lastPostId,
+            @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
             Pageable pageable);
+
+    @Query("SELECT CASE " +
+            "WHEN EXISTS (SELECT 1 FROM RoomPost r WHERE r.roomBoard.id = :boardId AND r.id = :postId) " +
+            "THEN (SELECT r.createdAt FROM RoomPost r WHERE r.roomBoard.id = :boardId AND r.id = :postId) " +
+            "ELSE (SELECT MAX(r.createdAt) FROM RoomPost r WHERE r.roomBoard.id = :boardId) " +
+            "END")
+    Optional<LocalDateTime> findCreatedAtByIdOrEarliest(@Param("boardId") Long boardId, @Param("postId") Long postId);
 }

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/RoomTroublePostRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/RoomTroublePostRepository.java
@@ -8,17 +8,25 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface RoomTroublePostRepository extends JpaRepository<RoomTroublePost, Long> {
     @Query("SELECT new gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto$TroublePostSummaryDto(" +
             "r.id, r.title, r.studyMate.user.nickname, r.createdAt, r.viewCount, SIZE(r.troublePostCommentList)) " +
             "FROM RoomTroublePost r " +
-            "WHERE r.roomBoard.id = :boardId AND r.id < :lastPostId " +
-            "ORDER BY r.createdAt DESC")
+            "WHERE r.roomBoard.id = :boardId AND r.createdAt <= :lastCreatedAt " +
+            "ORDER BY r.createdAt DESC, r.id DESC")
     List<RoomPostResponseDto.TroublePostSummaryDto> findTroublePostSummariesForInfiniteScroll(
             @Param("boardId") Long boardId,
-            @Param("lastPostId") Long lastPostId,
+            @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
             Pageable pageable);
-}
+
+    @Query("SELECT CASE " +
+            "WHEN EXISTS (SELECT 1 FROM RoomTroublePost r WHERE r.roomBoard.id = :boardId AND r.id = :postId) " +
+            "THEN (SELECT r.createdAt FROM RoomTroublePost r WHERE r.roomBoard.id = :boardId AND r.id = :postId) " +
+            "ELSE (SELECT MAX(r.createdAt) FROM RoomTroublePost r WHERE r.roomBoard.id = :boardId) " +
+            "END")
+    Optional<LocalDateTime> findCreatedAtByIdOrEarliest(@Param("boardId") Long boardId, @Param("postId") Long postId);}

--- a/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
+++ b/src/main/java/gaji/service/domain/roomBoard/repository/RoomTrouble/TroublePostCommentRepository.java
@@ -27,4 +27,5 @@ public interface TroublePostCommentRepository extends JpaRepository<TroublePostC
             "AND c.isReply = false " +
             "ORDER BY c.createdAt ASC, c.id ASC")
     Page<TroublePostComment> findOldestComments(@Param("postId") Long postId, Pageable pageable);
+
 }

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomInfo/RoomInfoPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomInfo/RoomInfoPostCommandServiceImpl.java
@@ -51,11 +51,11 @@ public class RoomInfoPostCommandServiceImpl implements RoomInfoPostCommandServic
         StudyMate studyMate = studyMateQueryService.findByUserIdAndRoomId(user.getId(), roomId);
 
         // 스터디룸 게시판 확인 또는 생성
-        RoomBoard roomBoard = roomBoardRepository.findByRoomId(roomId)
+        RoomBoard roomBoard = roomBoardRepository.findRoomBoardByRoomIdAndRoomPostType(roomId, RoomPostType.ROOM_INFORMATION_POST)
                 .orElseGet(() -> {
                     RoomBoard newRoomBoard = RoomBoard.builder()
                             .room(room)
-                            .roomPostType(RoomPostType.ROOM_TROUBLE_POST)
+                            .roomPostType(RoomPostType.ROOM_INFORMATION_POST)
                             .name(room.getName())
                             .build();
                     return roomBoardRepository.save(newRoomBoard);

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomInfo/RoomInfoPostQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomInfo/RoomInfoPostQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package gaji.service.domain.roomBoard.service.RoomInfo;
 
+import gaji.service.domain.enums.RoomPostType;
 import gaji.service.domain.roomBoard.code.RoomPostErrorStatus;
+import gaji.service.domain.roomBoard.entity.RoomBoard;
 import gaji.service.domain.roomBoard.entity.RoomInfo.InfoPostComment;
 import gaji.service.domain.roomBoard.entity.RoomInfo.RoomInfoPost;
+import gaji.service.domain.roomBoard.repository.RoomBoardRepository;
 import gaji.service.domain.roomBoard.repository.RoomInfo.InfoPostCommentRepository;
 import gaji.service.domain.roomBoard.repository.RoomInfo.RoomInfoPostRepository;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
@@ -13,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +28,7 @@ public class RoomInfoPostQueryServiceImpl implements RoomInfoPostQueryService{
     private final RoomInfoPostRepository roomInfoPostRepository;
     private final InfoPostCommentRepository infoPostCommentRepository;
     private final StudyMateQueryService studyMateQueryService;
+    private final RoomBoardRepository roomBoardRepository;
     @Override
     public RoomInfoPost findInfoPostById(Long PostId){
         return roomInfoPostRepository.findById(PostId)
@@ -44,9 +49,20 @@ public class RoomInfoPostQueryServiceImpl implements RoomInfoPostQueryService{
     }
 
     @Override
-    public List<RoomPostResponseDto.InfoPostSummaryDto> getNextPosts(Long boardId, Long lastPostId, int size) {
-        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return roomInfoPostRepository.findInfoPostSummariesForInfiniteScroll(boardId, lastPostId,pageable);
+    public List<RoomPostResponseDto.InfoPostSummaryDto> getNextPosts(Long roomId, Long lastPostId, int size) {
+        RoomBoard roomBoard = roomBoardRepository.findRoomBoardByRoomIdAndRoomPostType(roomId, RoomPostType.ROOM_INFORMATION_POST)
+                .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._ROOM_BOARD_NOT_FOUND));
+
+        LocalDateTime lastCreatedAt;
+        if (lastPostId == 0) {
+            lastCreatedAt = LocalDateTime.now();
+        } else {
+            lastCreatedAt = roomInfoPostRepository.findCreatedAtByIdOrEarliest(roomBoard.getId(), lastPostId)
+                    .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._POST_NOT_FOUND));
+        }
+
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt", "id"));
+        return roomInfoPostRepository.findInfoPostSummariesForInfiniteScroll(roomBoard.getId(), lastCreatedAt, pageable);
     }
 
 

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostCommandServiceImpl.java
@@ -51,7 +51,7 @@ public class RoomPostCommandServiceImpl implements RoomPostCommandService {
         StudyMate studyMate = studyMateQueryService.findByUserIdAndRoomId(user.getId(), roomId);
 
         // 스터디룸 게시판 확인 또는 생성
-        RoomBoard roomBoard = roomBoardRepository.findByRoomId(roomId)
+        RoomBoard roomBoard = roomBoardRepository.findRoomBoardByRoomIdAndRoomPostType(roomId,RoomPostType.ROOM_POST)
                 .orElseGet(() -> {
                     RoomBoard newRoomBoard = RoomBoard.builder()
                             .room(room)

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostQueryService.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostQueryService.java
@@ -13,7 +13,8 @@ public interface RoomPostQueryService {
 
 //    List<RoomPostResponseDto.TroublePostSummaryDto> getPaginatedTroublePosts(Long boardId, int page, int size);
 
-    List<RoomPostResponseDto.PostSummaryDto> getNextPosts(Long boardId, Long lastPostId, int size);
+
+    List<RoomPostResponseDto.PostSummaryDto> getNextPosts(Long roomId, Long lastPostId, int size);
 
     RoomPost findPostById(Long PostId);
 

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomPost/RoomPostQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package gaji.service.domain.roomBoard.service.RoomPost;
 
+import gaji.service.domain.enums.RoomPostType;
 import gaji.service.domain.roomBoard.code.RoomPostErrorStatus;
+import gaji.service.domain.roomBoard.entity.RoomBoard;
 import gaji.service.domain.roomBoard.entity.RoomPost.PostComment;
 import gaji.service.domain.roomBoard.entity.RoomPost.RoomPost;
+import gaji.service.domain.roomBoard.repository.RoomBoardRepository;
 import gaji.service.domain.roomBoard.repository.RoomPost.PostCommentRepository;
 import gaji.service.domain.roomBoard.repository.RoomPost.RoomPostQueryRepository;
 import gaji.service.domain.roomBoard.repository.RoomPost.RoomPostRepository;
@@ -14,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -26,6 +30,7 @@ public class RoomPostQueryServiceImpl implements RoomPostQueryService {
     private final RoomPostRepository roomPostRepository;
     private final PostCommentRepository postCommentRepository;
     private final StudyMateQueryService studyMateQueryService;
+    private final RoomBoardRepository roomBoardRepository;
 
     @Override
     public List<RoomPostResponseDto.PostListDto> getTop3RecentPosts(Long roomId) {
@@ -33,11 +38,21 @@ public class RoomPostQueryServiceImpl implements RoomPostQueryService {
     }
 
     @Override
-    public List<RoomPostResponseDto.PostSummaryDto> getNextPosts(Long boardId, Long lastPostId, int size) {
-        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return roomPostRepository.findPostSummariesForInfiniteScroll(boardId, lastPostId,pageable);
-    }
+    public List<RoomPostResponseDto.PostSummaryDto> getNextPosts(Long roomId, Long lastPostId, int size) {
+        RoomBoard roomBoard = roomBoardRepository.findRoomBoardByRoomIdAndRoomPostType(roomId, RoomPostType.ROOM_POST)
+                .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._ROOM_BOARD_NOT_FOUND));
 
+        LocalDateTime lastCreatedAt;
+        if (lastPostId == 0) {
+            lastCreatedAt = LocalDateTime.now();
+        } else {
+            lastCreatedAt = roomPostRepository.findCreatedAtByIdOrEarliest(roomBoard.getId(), lastPostId)
+                    .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._POST_NOT_FOUND));
+        }
+
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt", "id"));
+        return roomPostRepository.findPostSummariesForInfiniteScroll(roomBoard.getId(), lastCreatedAt, pageable);
+    }
     @Override
     public RoomPost findPostById(Long PostId){
         return roomPostRepository.findById(PostId)

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostCommandServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostCommandServiceImpl.java
@@ -68,7 +68,7 @@ public class RoomTroublePostCommandServiceImpl implements RoomTroublePostCommand
         StudyMate studyMate = studyMateQueryService.findByUserIdAndRoomId(user.getId(), roomId);
 
         // 스터디룸 게시판 확인 또는 생성
-        RoomBoard roomBoard = roomBoardRepository.findByRoomId(roomId)
+        RoomBoard roomBoard = roomBoardRepository.findRoomBoardByRoomIdAndRoomPostType(roomId , RoomPostType.ROOM_TROUBLE_POST)
                 .orElseGet(() -> {
                     RoomBoard newRoomBoard = RoomBoard.builder()
                             .room(room)

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
@@ -1,8 +1,11 @@
 package gaji.service.domain.roomBoard.service.RoomTrouble;
 
+import gaji.service.domain.enums.RoomPostType;
 import gaji.service.domain.roomBoard.code.RoomPostErrorStatus;
+import gaji.service.domain.roomBoard.entity.RoomBoard;
 import gaji.service.domain.roomBoard.entity.RoomTrouble.RoomTroublePost;
 import gaji.service.domain.roomBoard.entity.RoomTrouble.TroublePostComment;
+import gaji.service.domain.roomBoard.repository.RoomBoardRepository;
 import gaji.service.domain.roomBoard.repository.RoomTrouble.RoomTroublePostRepository;
 import gaji.service.domain.roomBoard.repository.RoomTrouble.TroublePostCommentRepository;
 import gaji.service.domain.roomBoard.web.dto.RoomPostResponseDto;
@@ -24,6 +27,7 @@ public class RoomTroublePostQueryServiceImpl implements RoomTroublePostQueryServ
     private final TroublePostCommentRepository troublePostCommentRepository;
     private final RoomTroublePostRepository roomTroublePostRepository;
     private final StudyMateQueryService studyMateQueryService;
+    private final RoomBoardRepository roomBoardRepository;
 
     @Override
     public TroublePostComment findCommentByCommentId(Long commentId){
@@ -38,9 +42,13 @@ public class RoomTroublePostQueryServiceImpl implements RoomTroublePostQueryServ
     }
 
     @Override
-    public List<RoomPostResponseDto.TroublePostSummaryDto> getNextTroublePosts(Long boardId, Long lastPostId, int size) {
+    public List<RoomPostResponseDto.TroublePostSummaryDto> getNextTroublePosts(Long roomId, Long lastPostId, int size) {
         Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
-        return roomTroublePostRepository.findTroublePostSummariesForInfiniteScroll(boardId, lastPostId,pageable);
+        RoomBoard roomBoard = roomBoardRepository.findRoomBoardByRoomIdAndRoomPostType(roomId, RoomPostType.ROOM_TROUBLE_POST)
+                .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._ROOM_BOARD_NOT_FOUND));
+        System.out.println("스터디룸 id: " + roomId);
+        System.out.println("스터디 boardId : " + roomBoard.getId());
+        return roomTroublePostRepository.findTroublePostSummariesForInfiniteScroll(roomBoard.getId(), lastPostId,pageable);
     }
 
 

--- a/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
+++ b/src/main/java/gaji/service/domain/roomBoard/service/RoomTrouble/RoomTroublePostQueryServiceImpl.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -43,12 +44,19 @@ public class RoomTroublePostQueryServiceImpl implements RoomTroublePostQueryServ
 
     @Override
     public List<RoomPostResponseDto.TroublePostSummaryDto> getNextTroublePosts(Long roomId, Long lastPostId, int size) {
-        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt"));
         RoomBoard roomBoard = roomBoardRepository.findRoomBoardByRoomIdAndRoomPostType(roomId, RoomPostType.ROOM_TROUBLE_POST)
                 .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._ROOM_BOARD_NOT_FOUND));
-        System.out.println("스터디룸 id: " + roomId);
-        System.out.println("스터디 boardId : " + roomBoard.getId());
-        return roomTroublePostRepository.findTroublePostSummariesForInfiniteScroll(roomBoard.getId(), lastPostId,pageable);
+
+        LocalDateTime lastCreatedAt;
+        if (lastPostId == 0) {
+            lastCreatedAt = LocalDateTime.now();
+        } else {
+            lastCreatedAt = roomTroublePostRepository.findCreatedAtByIdOrEarliest(roomBoard.getId(), lastPostId)
+                    .orElseThrow(() -> new RestApiException(RoomPostErrorStatus._POST_NOT_FOUND));
+        }
+
+        Pageable pageable = PageRequest.of(0, size, Sort.by(Sort.Direction.DESC, "createdAt", "id"));
+        return roomTroublePostRepository.findTroublePostSummariesForInfiniteScroll(roomBoard.getId(), lastCreatedAt, pageable);
     }
 
 

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomInfoPostController.java
@@ -146,17 +146,15 @@ public class RoomInfoPostController {
         return BaseResponse.onSuccess( "북마크가 성공적으로 삭제되었습니다.");
     }
 
-    @GetMapping("/{boardId}/info")
+    @GetMapping("/{roomId}/info/list")
     @Operation(summary = "게시글 무한 스크롤 조회", description = "게시글을 무한 스크롤 방식으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
-    public BaseResponse<List<RoomPostResponseDto.InfoPostSummaryDto>> getNextTroublePosts(
-            @PathVariable @Parameter(description = "게시판 ID") Long boardId,
+    public BaseResponse<List<RoomPostResponseDto.InfoPostSummaryDto>> getNextInfoPosts(
+            @PathVariable @Parameter(description = "스터디룸 ID") Long roomId,
             @RequestParam @Parameter(description = "마지막으로 로드된 게시글 ID") Long lastPostId,
             @RequestParam(defaultValue = "10") @Parameter(description = "조회할 게시글 수") int size) {
-
         List<RoomPostResponseDto.InfoPostSummaryDto> posts =
-                roomInfoPostQueryService.getNextPosts(boardId, lastPostId, size);
-
+                roomInfoPostQueryService.getNextPosts(roomId, lastPostId, size);
         return BaseResponse.onSuccess(posts);
     }
 

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomPostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomPostController.java
@@ -147,20 +147,31 @@ public class RoomPostController {
         return BaseResponse.onSuccess( "북마크가 성공적으로 삭제되었습니다.");
     }
 
-    @GetMapping("/{boardId}/post")
+//    @GetMapping("/{roomId}/post/list")
+//    @Operation(summary = "게시글 무한 스크롤 조회", description = "게시글을 무한 스크롤 방식으로 조회합니다.")
+//    @ApiResponse(responseCode = "200", description = "조회 성공")
+//    public BaseResponse<List<RoomPostResponseDto.PostSummaryDto>> getNextPosts(
+//            @PathVariable @Parameter(description = "스터디룸 ID") Long roomId,
+//            @RequestParam @Parameter(description = "마지막으로 로드된 게시글 ID") Long lastPostId,
+//            @RequestParam(defaultValue = "10") @Parameter(description = "조회할 게시글 수") int size) {
+//
+//        List<RoomPostResponseDto.PostSummaryDto> posts =
+//                roomPostQueryService.getNextPosts(roomId, lastPostId, size);
+//
+//        return BaseResponse.onSuccess(posts);
+//    }
+
+    @GetMapping("/{roomId}/post/list")
     @Operation(summary = "게시글 무한 스크롤 조회", description = "게시글을 무한 스크롤 방식으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<List<RoomPostResponseDto.PostSummaryDto>> getNextPosts(
-            @PathVariable @Parameter(description = "게시판 ID") Long boardId,
+            @PathVariable @Parameter(description = "스터디룸 ID") Long roomId,
             @RequestParam @Parameter(description = "마지막으로 로드된 게시글 ID") Long lastPostId,
             @RequestParam(defaultValue = "10") @Parameter(description = "조회할 게시글 수") int size) {
-
         List<RoomPostResponseDto.PostSummaryDto> posts =
-                roomPostQueryService.getNextPosts(boardId, lastPostId, size);
-
+                roomPostQueryService.getNextPosts(roomId, lastPostId, size);
         return BaseResponse.onSuccess(posts);
     }
-
     @PostMapping("/post/comments/{commentId}/replies")
     @Operation(summary = "게시글 댓글의 답글 작성 API")
     public BaseResponse<RoomPostResponseDto.toWriteCommentDto> addReply(

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
@@ -166,10 +166,8 @@ public class RoomTroublePostController {
             @PathVariable @Parameter(description = "게시판 ID") Long roomId,
             @RequestParam @Parameter(description = "마지막으로 로드된 게시글 ID") Long lastPostId,
             @RequestParam(defaultValue = "10") @Parameter(description = "조회할 게시글 수") int size) {
-
         List<RoomPostResponseDto.TroublePostSummaryDto> posts;
         posts = roomTroublePostQueryService.getNextTroublePosts(roomId, lastPostId, size);
-
         return BaseResponse.onSuccess(posts);
     }
 

--- a/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
+++ b/src/main/java/gaji/service/domain/roomBoard/web/controller/RoomTroublePostController.java
@@ -159,16 +159,16 @@ public class RoomTroublePostController {
         return BaseResponse.onSuccess(RoomPostConverter.toWriteCommentDto(replyComment));
     }
 
-    @GetMapping("/{boardId}/trouble")
+    @GetMapping("/{roomId}/trouble/list")
     @Operation(summary = "트러블 슈팅 게시글 무한 스크롤 조회", description = "트러블 슈팅 게시글을 무한 스크롤 방식으로 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공")
     public BaseResponse<List<RoomPostResponseDto.TroublePostSummaryDto>> getNextTroublePosts(
-            @PathVariable @Parameter(description = "게시판 ID") Long boardId,
+            @PathVariable @Parameter(description = "게시판 ID") Long roomId,
             @RequestParam @Parameter(description = "마지막으로 로드된 게시글 ID") Long lastPostId,
             @RequestParam(defaultValue = "10") @Parameter(description = "조회할 게시글 수") int size) {
 
-        List<RoomPostResponseDto.TroublePostSummaryDto> posts =
-                roomTroublePostQueryService.getNextTroublePosts(boardId, lastPostId, size);
+        List<RoomPostResponseDto.TroublePostSummaryDto> posts;
+        posts = roomTroublePostQueryService.getNextTroublePosts(roomId, lastPostId, size);
 
         return BaseResponse.onSuccess(posts);
     }


### PR DESCRIPTION
## PR 타입(하나 이상의 PR 타입을 선택해주세요)
- [ ] 기능 추가
- [ ] 기능 삭제
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 반영 브랜치
ex) feat/login -> develop

## 변경 사항
- 정보나눔 게시글, 게시글, 트러블 슈팅 게시글을 roomId만으로 무한 페이징 방식으로 조회 가능하도록 수정했습니다.
## 이슈
- 공지사항이 페이징 방식으로 구현돼 있어서 무한 스크롤 방식으로 변경하였습니다.

## 테스트 결과
### 트러블 슈팅 게시글
![image](https://github.com/user-attachments/assets/6a783271-ce3c-41cb-9659-facd28c29850)


### 게시글 
![image](https://github.com/user-attachments/assets/b60383f0-3171-4d21-9450-077938d3465c)

### 정보나눔 게시글
![image](https://github.com/user-attachments/assets/f1d013be-ab03-4f38-a206-9ab6db20843f)

### 공지사항 목록 조회
![image](https://github.com/user-attachments/assets/a44ee4cc-6059-42ad-b9af-0f692d1898a2)

